### PR TITLE
Rename all the crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,23 +554,6 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "kernel"
-version = "0.1.0"
-dependencies = [
- "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "nametbd-core 0.1.0",
- "nametbd-tcp-hosted 0.1.0",
- "nametbd-tcp-interface 0.1.0",
- "nametbd-vulkan-interface 0.1.0",
- "nametbd-wasi-hosted 0.1.0",
- "nametbd-window-interface 0.1.0",
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.20.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +738,23 @@ dependencies = [
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.5.1 (git+https://github.com/paritytech/wasmi)",
+]
+
+[[package]]
+name = "nametbd-gui-kernel"
+version = "0.1.0"
+dependencies = [
+ "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-core 0.1.0",
+ "nametbd-tcp-hosted 0.1.0",
+ "nametbd-tcp-interface 0.1.0",
+ "nametbd-vulkan-interface 0.1.0",
+ "nametbd-wasi-hosted 0.1.0",
+ "nametbd-window-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.20.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,34 +540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hosted-tcp"
-version = "0.1.0"
-dependencies = [
- "async-std 0.99.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tcp 0.1.0",
-]
-
-[[package]]
-name = "hosted-wasi"
-version = "0.1.0"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel-core 0.1.0",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.5.1 (git+https://github.com/paritytech/wasmi)",
-]
-
-[[package]]
-name = "interface"
-version = "0.1.0"
-dependencies = [
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
-
-[[package]]
 name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,41 +558,16 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "hosted-tcp 0.1.0",
- "hosted-wasi 0.1.0",
- "kernel-core 0.1.0",
+ "nametbd-core 0.1.0",
+ "nametbd-tcp-hosted 0.1.0",
+ "nametbd-tcp-interface 0.1.0",
+ "nametbd-vulkan-interface 0.1.0",
+ "nametbd-wasi-hosted 0.1.0",
+ "nametbd-window-interface 0.1.0",
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tcp 0.1.0",
- "vulkan 0.1.0",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "window 0.1.0",
  "winit 0.20.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kernel-core"
-version = "0.1.0"
-dependencies = [
- "bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "interface 0.1.0",
- "loader 0.1.0",
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_distr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
- "threads 0.1.0",
- "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.5.1 (git+https://github.com/paritytech/wasmi)",
 ]
 
 [[package]]
@@ -678,14 +625,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "loader"
-version = "0.1.0"
-dependencies = [
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
 ]
 
 [[package]]
@@ -791,6 +730,116 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-core"
+version = "0.1.0"
+dependencies = [
+ "bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-interface-interface 0.1.0",
+ "nametbd-loader-interface 0.1.0",
+ "nametbd-syscalls-interface 0.1.0",
+ "nametbd-threads-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_distr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.5.1 (git+https://github.com/paritytech/wasmi)",
+]
+
+[[package]]
+name = "nametbd-interface-interface"
+version = "0.1.0"
+dependencies = [
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-loader-interface"
+version = "0.1.0"
+dependencies = [
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-syscalls-interface"
+version = "0.1.0"
+dependencies = [
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "send_wrapper 0.2.0 (git+https://github.com/tomaka/send_wrapper?branch=patch-1)",
+]
+
+[[package]]
+name = "nametbd-tcp-hosted"
+version = "0.1.0"
+dependencies = [
+ "async-std 0.99.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-tcp-interface 0.1.0",
+]
+
+[[package]]
+name = "nametbd-tcp-interface"
+version = "0.1.0"
+dependencies = [
+ "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-threads-interface"
+version = "0.1.0"
+dependencies = [
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-vulkan-interface"
+version = "0.1.0"
+dependencies = [
+ "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-wasi-hosted"
+version = "0.1.0"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-core 0.1.0",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.5.1 (git+https://github.com/paritytech/wasmi)",
+]
+
+[[package]]
+name = "nametbd-window-interface"
+version = "0.1.0"
+dependencies = [
+ "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1241,36 +1290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syscalls"
-version = "0.1.0"
-dependencies = [
- "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "send_wrapper 0.2.0 (git+https://github.com/tomaka/send_wrapper?branch=patch-1)",
-]
-
-[[package]]
-name = "tcp"
-version = "0.1.0"
-dependencies = [
- "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
-
-[[package]]
-name = "threads"
-version = "0.1.0"
-dependencies = [
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,16 +1316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "vulkan"
-version = "0.1.0"
-dependencies = [
- "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
- "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "wabt"
@@ -1457,15 +1466,6 @@ dependencies = [
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "window"
-version = "0.1.0"
-dependencies = [
- "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
 
 [[package]]
 name = "winit"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "kernel-core"
+name = "nametbd-core"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
@@ -13,17 +13,17 @@ crossbeam = "0.7.2"
 err-derive = "0.1.5"
 futures-preview = { version = "0.3.0-alpha.18", default-features = false }      # TODO: necessary?
 hashbrown = "0.6.0"
-interface = { path = "../interfaces/interface", default-features = false }
-loader = { path = "../interfaces/loader", default-features = false }
+nametbd-interface-interface = { path = "../interfaces/interface", default-features = false }
+nametbd-loader-interface = { path = "../interfaces/loader", default-features = false }
+nametbd-syscalls-interface = { path = "../interfaces/syscalls", default-features = false }
+nametbd-threads-interface = { path = "../interfaces/threads", default-features = false }
 parity-scale-codec = { version = "1.0.5", features = ["derive"] } # TODO: might be unused
 rand = "0.7"        # TODO: remove in favour of fine grained rand crates
 rand_chacha = { version = "0.2.1", default-features = false }
 rand_core = { version = "0.5.0", default-features = false }
 rand_distr = { version = "0.2.2", default-features = false }
-threads = { path = "../interfaces/threads", default-features = false }
 sha2 = "0.8.0"
 smallvec = { version = "0.6.10", default-features = false }
-syscalls = { path = "../interfaces/syscalls", default-features = false }
 wabt = "0.9.1"
 wasmi = { git = "https://github.com/paritytech/wasmi", default-features = false, features = ["core", "std"] }
 #wasmi = { version = "0.5.1", default-features = false, features = ["core"] }       # TODO: https://github.com/paritytech/wasmi/pull/210

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -158,11 +158,11 @@ enum CoreRunOutcomeInner {
 struct Process {
     /// Messages available for retrieval by the process by calling `next_message`.
     ///
-    /// Note that the [`ResponseMessage::index_in_list`](syscalls::ffi::ResponseMessage::index_in_list)
-    /// and [`InterfaceMessage::index_in_list`](syscalls::ffi::InterfaceMessage::index_in_list) fields are
+    /// Note that the [`ResponseMessage::index_in_list`](nametbd_syscalls_interface::ffi::ResponseMessage::index_in_list)
+    /// and [`InterfaceMessage::index_in_list`](nametbd_syscalls_interface::ffi::InterfaceMessage::index_in_list) fields are
     /// set to a dummy value, and must be filled before actually delivering the message.
     // TODO: call shrink_to_fit from time to time
-    messages_queue: VecDeque<syscalls::ffi::Message>,
+    messages_queue: VecDeque<nametbd_syscalls_interface::ffi::Message>,
 }
 
 /// Additional information about a thread.
@@ -391,8 +391,8 @@ impl<T> Core<T> {
                             .expect("Interface handler not found")
                         {
                             InterfaceHandler::Process(pid) => {
-                                let message = syscalls::ffi::Message::Interface(
-                                    syscalls::ffi::InterfaceMessage {
+                                let message = nametbd_syscalls_interface::ffi::Message::Interface(
+                                    nametbd_syscalls_interface::ffi::InterfaceMessage {
                                         interface,
                                         index_in_list: 0,
                                         message_id,
@@ -500,7 +500,7 @@ impl<T> Core<T> {
         interface: [u8; 32],
         message: impl Encode,
     ) -> Result<(), ()> {
-        let message = syscalls::ffi::Message::Interface(syscalls::ffi::InterfaceMessage {
+        let message = nametbd_syscalls_interface::ffi::Message::Interface(nametbd_syscalls_interface::ffi::InterfaceMessage {
             interface,
             message_id: None,
             emitter_pid: None,
@@ -549,7 +549,7 @@ impl<T> Core<T> {
             };
         };
 
-        let message = syscalls::ffi::Message::Interface(syscalls::ffi::InterfaceMessage {
+        let message = nametbd_syscalls_interface::ffi::Message::Interface(nametbd_syscalls_interface::ffi::InterfaceMessage {
             interface,
             message_id: Some(message_id),
             emitter_pid: None,
@@ -596,7 +596,7 @@ impl<T> Core<T> {
         response: &[u8],
         answerer_pid: Option<Pid>,
     ) -> Option<CoreRunOutcomeInner> {
-        let actual_message = syscalls::ffi::Message::Response(syscalls::ffi::ResponseMessage {
+        let actual_message = nametbd_syscalls_interface::ffi::Message::Response(nametbd_syscalls_interface::ffi::ResponseMessage {
             message_id,
             // We a dummy value here and fill it up later when actually delivering the message.
             index_in_list: 0,
@@ -869,8 +869,8 @@ fn try_resume_message_wait(thread: &mut processes::ProcessesCollectionThread<Pro
 
         // For that message in queue, grab the value that must be in `msg_ids` in order to match.
         let msg_id = match &thread.process_user_data().messages_queue[index_in_queue] {
-            syscalls::ffi::Message::Interface(_) => 1,
-            syscalls::ffi::Message::Response(response) => {
+            nametbd_syscalls_interface::ffi::Message::Interface(_) => 1,
+            nametbd_syscalls_interface::ffi::Message::Response(response) => {
                 debug_assert!(response.message_id >= 2);
                 response.message_id
             }
@@ -887,10 +887,10 @@ fn try_resume_message_wait(thread: &mut processes::ProcessesCollectionThread<Pro
 
     // Adjust the `index_in_list` field of the message to match what we have.
     match thread.process_user_data().messages_queue[index_in_queue] {
-        syscalls::ffi::Message::Response(ref mut response) => {
+        nametbd_syscalls_interface::ffi::Message::Response(ref mut response) => {
             response.index_in_list = index_in_msg_ids;
         }
-        syscalls::ffi::Message::Interface(ref mut interface) => {
+        nametbd_syscalls_interface::ffi::Message::Interface(ref mut interface) => {
             interface.index_in_list = index_in_msg_ids;
         }
     }

--- a/core/src/signature.rs
+++ b/core/src/signature.rs
@@ -27,7 +27,7 @@ pub struct Signature {
 /// # Example
 ///
 /// ```
-/// let _sig: kernel_core::signature::Signature = kernel_core::sig!((I32, I64) -> I32);
+/// let _sig: nametbd_core::signature::Signature = nametbd_core::sig!((I32, I64) -> I32);
 /// ```
 #[macro_export]
 macro_rules! sig {

--- a/hosted/kernel/Cargo.toml
+++ b/hosted/kernel/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "kernel"
+name = "nametbd-gui-kernel"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 publish = false
-default-run = "kernel"
+default-run = "nametbd-gui-kernel"
 
 [dependencies]
 futures-preview = { version = "0.3.0-alpha.18", features = ["async-await", "nightly"] }

--- a/hosted/kernel/Cargo.toml
+++ b/hosted/kernel/Cargo.toml
@@ -9,14 +9,14 @@ default-run = "kernel"
 
 [dependencies]
 futures-preview = { version = "0.3.0-alpha.18", features = ["async-await", "nightly"] }
-hosted-tcp = { path = "../tcp" }
-hosted-wasi = { path = "../wasi" }
-kernel-core = { path = "../../core" }
+nametbd-core = { path = "../../core" }
+nametbd-tcp-hosted = { path = "../tcp" }
+nametbd-tcp-interface = { path = "../../interfaces/tcp" }
+nametbd-vulkan-interface = { path = "../../interfaces/vulkan" }
+nametbd-wasi-hosted = { path = "../wasi" }
+nametbd-window-interface = { path = "../../interfaces/window" }
 parity-scale-codec = "1.0.5"
-tcp = { path = "../../interfaces/tcp" }
-vulkan = { path = "../../interfaces/vulkan" }
 wasi = "0.7.0"
-window = { path = "../../interfaces/window" }
 winit = "0.20.0-alpha3"
 
 [build-dependencies]

--- a/hosted/kernel/src/main.rs
+++ b/hosted/kernel/src/main.rs
@@ -66,56 +66,56 @@ async fn async_main(
         oneshot::Sender<Result<winit::window::Window, winit::error::OsError>>,
     >,
 ) {
-    let module = kernel_core::module::Module::from_bytes(
+    let module = nametbd_core::module::Module::from_bytes(
         &include_bytes!("../../../modules/target/wasm32-wasi/debug/vulkan-triangle.wasm")[..],
     );
 
-    let mut system = hosted_wasi::register_extrinsics(kernel_core::system::System::new())
-        .with_interface_handler(tcp::ffi::INTERFACE)
-        .with_interface_handler(vulkan::INTERFACE)
-        .with_interface_handler(window::ffi::INTERFACE)
+    let mut system = nametbd_wasi_hosted::register_extrinsics(nametbd_core::system::System::new())
+        .with_interface_handler(nametbd_tcp_interface::ffi::INTERFACE)
+        .with_interface_handler(nametbd_vulkan_interface::INTERFACE)
+        .with_interface_handler(nametbd_window_interface::ffi::INTERFACE)
         .with_main_program(module)
         .build();
 
-    let mut tcp = hosted_tcp::TcpState::new();
+    let mut tcp = nametbd_tcp_hosted::TcpState::new();
     let mut vk = {
         #[link(name = "vulkan")]
         extern "system" {
             fn vkGetInstanceProcAddr(
                 instance: usize,
                 pName: *const u8,
-            ) -> vulkan::PFN_vkVoidFunction;
+            ) -> nametbd_vulkan_interface::PFN_vkVoidFunction;
         }
-        vulkan::VulkanRedirect::new(vkGetInstanceProcAddr)
+        nametbd_vulkan_interface::VulkanRedirect::new(vkGetInstanceProcAddr)
     };
     let mut windows = Vec::new();
 
     loop {
         let result = loop {
             let only_poll = match system.run() {
-                kernel_core::system::SystemRunOutcome::ThreadWaitExtrinsic {
+                nametbd_core::system::SystemRunOutcome::ThreadWaitExtrinsic {
                     pid,
                     thread_id,
                     extrinsic,
                     params,
                 } => {
-                    hosted_wasi::handle_wasi(&mut system, extrinsic, pid, thread_id, params);
+                    nametbd_wasi_hosted::handle_wasi(&mut system, extrinsic, pid, thread_id, params);
                     true
                 }
-                kernel_core::system::SystemRunOutcome::InterfaceMessage {
+                nametbd_core::system::SystemRunOutcome::InterfaceMessage {
                     message_id,
                     interface,
                     message,
-                } if interface == tcp::ffi::INTERFACE => {
-                    let message: tcp::ffi::TcpMessage = DecodeAll::decode_all(&message).unwrap();
+                } if interface == nametbd_tcp_interface::ffi::INTERFACE => {
+                    let message: nametbd_tcp_interface::ffi::TcpMessage = DecodeAll::decode_all(&message).unwrap();
                     tcp.handle_message(message_id, message);
                     continue;
                 }
-                kernel_core::system::SystemRunOutcome::InterfaceMessage {
+                nametbd_core::system::SystemRunOutcome::InterfaceMessage {
                     message_id,
                     interface,
                     message,
-                } if interface == vulkan::INTERFACE => {
+                } if interface == nametbd_vulkan_interface::INTERFACE => {
                     // TODO:
                     println!("received vk message: {:?}", message);
                     if let Some(response) = vk.handle(0, &message) {
@@ -124,22 +124,22 @@ async fn async_main(
                     }
                     continue;
                 }
-                kernel_core::system::SystemRunOutcome::InterfaceMessage {
+                nametbd_core::system::SystemRunOutcome::InterfaceMessage {
                     message_id,
                     interface,
                     message,
-                } if interface == window::ffi::INTERFACE => {
+                } if interface == nametbd_window_interface::ffi::INTERFACE => {
                     println!("received window message: {:?}", message);
                     let (tx, rx) = oneshot::channel();
                     win_open_rq.unbounded_send(tx).unwrap();
                     let window = rx.await.unwrap().unwrap();
                     windows.push(window);
-                    system.answer_message(message_id.unwrap(), &window::ffi::WindowOpenResponse {
+                    system.answer_message(message_id.unwrap(), &nametbd_window_interface::ffi::WindowOpenResponse {
                         result: Ok(0),      // TODO: correct ID
                     }.encode());
                     continue;
                 }
-                kernel_core::system::SystemRunOutcome::Idle => false,
+                nametbd_core::system::SystemRunOutcome::Idle => false,
                 other => break other,
             };
 
@@ -157,18 +157,18 @@ async fn async_main(
             };
 
             let (msg_to_respond, response_bytes) = match event {
-                hosted_tcp::TcpResponse::Open(msg_id, msg) => (msg_id, msg.encode()),
-                hosted_tcp::TcpResponse::Read(msg_id, msg) => (msg_id, msg.encode()),
-                hosted_tcp::TcpResponse::Write(msg_id, msg) => (msg_id, msg.encode()),
+                nametbd_tcp_hosted::TcpResponse::Open(msg_id, msg) => (msg_id, msg.encode()),
+                nametbd_tcp_hosted::TcpResponse::Read(msg_id, msg) => (msg_id, msg.encode()),
+                nametbd_tcp_hosted::TcpResponse::Write(msg_id, msg) => (msg_id, msg.encode()),
             };
             system.answer_message(msg_to_respond, &response_bytes);
         };
 
         match result {
-            kernel_core::system::SystemRunOutcome::ProgramFinished { pid, return_value } => {
+            nametbd_core::system::SystemRunOutcome::ProgramFinished { pid, return_value } => {
                 println!("Program finished {:?} => {:?}", pid, return_value);
             }
-            kernel_core::system::SystemRunOutcome::ProgramCrashed { pid, error } => {
+            nametbd_core::system::SystemRunOutcome::ProgramCrashed { pid, error } => {
                 println!("Program crashed {:?} => {:?}", pid, error);
             }
             _ => panic!(),

--- a/hosted/tcp/Cargo.toml
+++ b/hosted/tcp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hosted-tcp"
+name = "nametbd-tcp-hosted"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
@@ -10,4 +10,4 @@ publish = false
 async-std = "0.99.5"
 fnv = "1.0"
 futures-preview = { version = "0.3.0-alpha.18", features = ["async-await", "nightly"] }
-tcp = { path = "../../interfaces/tcp" }
+nametbd-tcp-interface = { path = "../../interfaces/tcp" }

--- a/hosted/tcp/src/lib.rs
+++ b/hosted/tcp/src/lib.rs
@@ -33,9 +33,9 @@ pub struct TcpState {
 
 #[derive(Debug)]
 pub enum TcpResponse {
-    Open(u64, tcp::ffi::TcpOpenResponse),
-    Read(u64, tcp::ffi::TcpReadResponse),
-    Write(u64, tcp::ffi::TcpWriteResponse),
+    Open(u64, nametbd_tcp_interface::ffi::TcpOpenResponse),
+    Read(u64, nametbd_tcp_interface::ffi::TcpReadResponse),
+    Write(u64, nametbd_tcp_interface::ffi::TcpWriteResponse),
 }
 
 impl TcpState {
@@ -46,9 +46,9 @@ impl TcpState {
         }
     }
 
-    pub fn handle_message(&mut self, message_id: Option<u64>, message: tcp::ffi::TcpMessage) {
+    pub fn handle_message(&mut self, message_id: Option<u64>, message: nametbd_tcp_interface::ffi::TcpMessage) {
         match message {
-            tcp::ffi::TcpMessage::Open(open) => {
+            nametbd_tcp_interface::ffi::TcpMessage::Open(open) => {
                 let message_id = message_id.unwrap();
                 let ip_addr = Ipv6Addr::from(open.ip);
                 let socket_addr = if let Some(ip_addr) = ip_addr.to_ipv4() {
@@ -64,17 +64,17 @@ impl TcpState {
                     TcpConnec::Connecting(socket_id, message_id, Box::pin(socket)),
                 );
             }
-            tcp::ffi::TcpMessage::Close(close) => {
+            nametbd_tcp_interface::ffi::TcpMessage::Close(close) => {
                 let _ = self.sockets.remove(&close.socket_id);
             }
-            tcp::ffi::TcpMessage::Read(read) => {
+            nametbd_tcp_interface::ffi::TcpMessage::Read(read) => {
                 let message_id = message_id.unwrap();
                 self.sockets
                     .get_mut(&read.socket_id)
                     .unwrap()
                     .start_read(message_id);
             }
-            tcp::ffi::TcpMessage::Write(write) => {
+            nametbd_tcp_interface::ffi::TcpMessage::Write(write) => {
                 let message_id = message_id.unwrap();
                 self.sockets
                     .get_mut(&write.socket_id)
@@ -147,7 +147,7 @@ impl TcpConnec {
                         Ok(socket) => {
                             let ev = TcpResponse::Open(
                                 *message_id,
-                                tcp::ffi::TcpOpenResponse { result: Ok(*id) },
+                                nametbd_tcp_interface::ffi::TcpOpenResponse { result: Ok(*id) },
                             );
                             (
                                 TcpConnec::Socket {
@@ -162,7 +162,7 @@ impl TcpConnec {
                         Err(_) => {
                             let ev = TcpResponse::Open(
                                 *message_id,
-                                tcp::ffi::TcpOpenResponse { result: Err(()) },
+                                nametbd_tcp_interface::ffi::TcpOpenResponse { result: Err(()) },
                             );
                             (TcpConnec::Poisoned, ev)
                         }
@@ -200,7 +200,7 @@ impl TcpConnec {
                         *pending_write = None;
                         return Poll::Ready(TcpResponse::Write(
                             msg_id,
-                            tcp::ffi::TcpWriteResponse { result: Ok(()) },
+                            nametbd_tcp_interface::ffi::TcpWriteResponse { result: Ok(()) },
                         ));
                     }
 
@@ -212,7 +212,7 @@ impl TcpConnec {
                         *pending_read = None;
                         return Poll::Ready(TcpResponse::Read(
                             msg_id,
-                            tcp::ffi::TcpReadResponse {
+                            nametbd_tcp_interface::ffi::TcpReadResponse {
                                 result: Ok(buf[..num_read].to_vec()),
                             },
                         ));

--- a/hosted/wasi/Cargo.toml
+++ b/hosted/wasi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hosted-wasi"
+name = "nametbd-wasi-hosted"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
-kernel-core = { path = "../../core" }
+nametbd-core = { path = "../../core" }
 rand = "0.7"
 
 # TODO: remove

--- a/hosted/wasi/src/lib.rs
+++ b/hosted/wasi/src/lib.rs
@@ -14,8 +14,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use byteorder::{ByteOrder as _, LittleEndian};
-use kernel_core::scheduler::{Pid, ThreadId};
-use kernel_core::system::{System, SystemBuilder};
+use nametbd_core::scheduler::{Pid, ThreadId};
+use nametbd_core::system::{System, SystemBuilder};
 use std::io::Write as _;
 
 // TODO: lots of unwraps as `as` conversions in this module
@@ -46,74 +46,74 @@ pub fn register_extrinsics<T: From<WasiExtrinsic>>(system: SystemBuilder<T>) -> 
         .with_extrinsic(
             "wasi_unstable",
             "args_get",
-            kernel_core::sig!((I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::ArgsGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "args_sizes_get",
-            kernel_core::sig!((I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::ArgsSizesGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "clock_time_get",
             // TODO: bad signature
-            kernel_core::sig!((I32, I64) -> I64),
+            nametbd_core::sig!((I32, I64) -> I64),
             WasiExtrinsic(WasiExtrinsicInner::ClockTimeGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "environ_get",
-            kernel_core::sig!((I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::EnvironGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "environ_sizes_get",
-            kernel_core::sig!((I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::EnvironSizesGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "fd_prestat_get",
-            kernel_core::sig!((I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::FdPrestatGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "fd_prestat_dir_name",
-            kernel_core::sig!((I32, I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::FdPrestatDirName).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "fd_fdstat_get",
-            kernel_core::sig!((I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::FdFdstatGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "fd_write",
-            kernel_core::sig!((I32, I32, I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32, I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::FdWrite).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "proc_exit",
-            kernel_core::sig!((I32)),
+            nametbd_core::sig!((I32)),
             WasiExtrinsic(WasiExtrinsicInner::ProcExit).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "random_get",
-            kernel_core::sig!((I32, I32) -> I32),
+            nametbd_core::sig!((I32, I32) -> I32),
             WasiExtrinsic(WasiExtrinsicInner::RandomGet).into(),
         )
         .with_extrinsic(
             "wasi_unstable",
             "sched_yield",
-            kernel_core::sig!(()),
+            nametbd_core::sig!(()),
             WasiExtrinsic(WasiExtrinsicInner::SchedYield).into(),
         )
 }
@@ -189,9 +189,9 @@ pub fn handle_wasi(
 }
 
 fn fd_write(
-    system: &mut kernel_core::system::System<impl Clone>,
-    pid: kernel_core::scheduler::Pid,
-    thread_id: kernel_core::scheduler::ThreadId,
+    system: &mut nametbd_core::system::System<impl Clone>,
+    pid: nametbd_core::scheduler::Pid,
+    thread_id: nametbd_core::scheduler::ThreadId,
     params: Vec<wasmi::RuntimeValue>,
 ) {
     assert_eq!(params.len(), 4); // TODO: what to do when it's not the case?

--- a/interfaces/interface/Cargo.toml
+++ b/interfaces/interface/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "interface"
+name = "nametbd-interface-interface"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+nametbd-syscalls-interface = { path = "../syscalls" }
 parity-scale-codec = { version = "1.0.5", features = ["derive"] }
-syscalls = { path = "../syscalls" }

--- a/interfaces/interface/src/lib.rs
+++ b/interfaces/interface/src/lib.rs
@@ -35,7 +35,7 @@ pub async fn register_interface(hash: [u8; 32]) -> Result<(), InterfaceRegisterE
     let msg = ffi::InterfaceMessage::Register(hash);
     // TODO: we unwrap cause there's always something that handles interface registration; is that correct?
     let rep: ffi::InterfaceRegisterResponse =
-        syscalls::emit_message_with_response(ffi::INTERFACE, msg)
+        nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
             .await
             .unwrap();
     rep.result

--- a/interfaces/loader/Cargo.toml
+++ b/interfaces/loader/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "loader"
+name = "nametbd-loader-interface"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+nametbd-syscalls-interface = { path = "../syscalls" }
 parity-scale-codec = { version = "1.0.5", features = ["derive"] }
-syscalls = { path = "../syscalls" }

--- a/interfaces/loader/src/lib.rs
+++ b/interfaces/loader/src/lib.rs
@@ -29,7 +29,7 @@ pub mod ffi;
 #[cfg(target_arch = "wasm32")] // TODO: bad
 pub async fn load(hash: [u8; 32]) -> Result<Vec<u8>, ()> {
     let msg = ffi::LoaderMessage::Load(hash);
-    let rep: ffi::LoadResponse = syscalls::emit_message_with_response(ffi::INTERFACE, msg).await?;
+    let rep: ffi::LoadResponse = nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).await?;
     rep.result
 }
 

--- a/interfaces/syscalls/Cargo.toml
+++ b/interfaces/syscalls/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "syscalls"
+name = "nametbd-syscalls-interface"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]

--- a/interfaces/tcp/Cargo.toml
+++ b/interfaces/tcp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tcp"
+name = "nametbd-tcp-interface"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 futures-preview = "0.3.0-alpha.18"
+nametbd-syscalls-interface = { path = "../syscalls" }
 parity-scale-codec = { version = "1.0.5", features = ["derive"] }
-syscalls = { path = "../syscalls" }

--- a/interfaces/tcp/src/lib.rs
+++ b/interfaces/tcp/src/lib.rs
@@ -48,12 +48,12 @@ impl TcpStream {
             },
         });
 
-        let msg_id = syscalls::emit_message(&ffi::INTERFACE, &tcp_open, true)
+        let msg_id = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_open, true)
             .unwrap()
             .unwrap();
 
         async move {
-            let message: ffi::TcpOpenResponse = syscalls::message_response(msg_id).await;
+            let message: ffi::TcpOpenResponse = nametbd_syscalls_interface::message_response(msg_id).await;
             let handle = message.result.unwrap();
 
             TcpStream {
@@ -86,10 +86,10 @@ impl AsyncRead for TcpStream {
             let tcp_read = ffi::TcpMessage::Read(ffi::TcpRead {
                 socket_id: self.handle,
             });
-            let msg_id = syscalls::emit_message(&ffi::INTERFACE, &tcp_read, true)
+            let msg_id = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_read, true)
                 .unwrap()
                 .unwrap();
-            self.pending_read = Some(Box::pin(syscalls::message_response(msg_id)));
+            self.pending_read = Some(Box::pin(nametbd_syscalls_interface::message_response(msg_id)));
         }
     }
 
@@ -113,10 +113,10 @@ impl AsyncWrite for TcpStream {
             socket_id: self.handle,
             data: buf.to_vec(),
         });
-        let msg_id = syscalls::emit_message(&ffi::INTERFACE, &tcp_write, true)
+        let msg_id = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_write, true)
             .unwrap()
             .unwrap();
-        self.pending_write = Some(Box::pin(syscalls::message_response(msg_id)));
+        self.pending_write = Some(Box::pin(nametbd_syscalls_interface::message_response(msg_id)));
         Poll::Ready(Ok(buf.len()))
     }
 
@@ -135,6 +135,6 @@ impl Drop for TcpStream {
             socket_id: self.handle,
         });
 
-        syscalls::emit_message(&ffi::INTERFACE, &tcp_close, false);
+        nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_close, false);
     }
 }

--- a/interfaces/threads/Cargo.toml
+++ b/interfaces/threads/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "threads"
+name = "nametbd-threads-interface"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+nametbd-syscalls-interface = { path = "../syscalls" }
 parity-scale-codec = { version = "1.0.5", features = ["derive"] }
-syscalls = { path = "../syscalls" }

--- a/interfaces/threads/src/lib.rs
+++ b/interfaces/threads/src/lib.rs
@@ -44,7 +44,7 @@ pub unsafe fn spawn_thread(function: impl FnOnce()) {
         user_data: Box::into_raw(function_box) as usize as u32,
     });
 
-    syscalls::emit_message(&ffi::INTERFACE, &thread_new, false).unwrap();
+    nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &thread_new, false).unwrap();
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/interfaces/vulkan/Cargo.toml
+++ b/interfaces/vulkan/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vulkan"
+name = "nametbd-vulkan-interface"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
@@ -8,8 +8,8 @@ build = "build/main.rs"
 
 [dependencies]
 hashbrown = "0.6.0"
+nametbd-syscalls-interface = { path = "../syscalls" }
 parity-scale-codec = "1.0.5"
-syscalls = { path = "../syscalls" }
 
 [build-dependencies]
 xml-rs = "0.8.0"

--- a/interfaces/vulkan/build/main.rs
+++ b/interfaces/vulkan/build/main.rs
@@ -182,10 +182,10 @@ fn write_commands_wrappers(mut out: impl Write, registry: &parse::VkRegistry) {
             );
         }
 
-        writeln!(out, "    let msg_id = syscalls::emit_message_raw(&INTERFACE, &msg_buf, true).unwrap().unwrap();").unwrap();
+        writeln!(out, "    let msg_id = nametbd_syscalls_interface::emit_message_raw(&INTERFACE, &msg_buf, true).unwrap().unwrap();").unwrap();
         writeln!(
             out,
-            "    let response = syscalls::message_response_sync_raw(msg_id);"
+            "    let response = nametbd_syscalls_interface::message_response_sync_raw(msg_id);"
         )
         .unwrap();
         writeln!(out, "    println!(\"got response: {{:?}}\", response);").unwrap();

--- a/interfaces/window/Cargo.toml
+++ b/interfaces/window/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "window"
+name = "nametbd-window-interface"
 version = "0.1.0"
 license = "GPL-3.0-or-later"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 futures-preview = "0.3.0-alpha.18"
+nametbd-syscalls-interface = { path = "../syscalls" }
 parity-scale-codec = { version = "1.0.5", features = ["derive"] }
-syscalls = { path = "../syscalls" }

--- a/interfaces/window/src/lib.rs
+++ b/interfaces/window/src/lib.rs
@@ -29,7 +29,7 @@ impl Window {
     pub async fn open() -> Result<Window, ()> {
         let open = ffi::WindowMessage::Open(ffi::WindowOpen {});
         let response: ffi::WindowOpenResponse =
-            syscalls::emit_message_with_response(ffi::INTERFACE, open).await?;
+            nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, open).await?;
         Ok(Window {
             handle: response.result?,
         })
@@ -42,6 +42,6 @@ impl Drop for Window {
             window_id: self.handle,
         });
 
-        let _ = syscalls::emit_message(&ffi::INTERFACE, &close, false);
+        let _ = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &close, false);
     }
 }

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -532,14 +532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interface"
-version = "0.1.0"
-dependencies = [
- "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
-
-[[package]]
 name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,17 +546,17 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "interface 0.1.0",
  "libp2p-core 0.12.0 (git+https://github.com/tomaka/libp2p-rs?branch=wasi)",
  "libp2p-kad 0.12.0 (git+https://github.com/tomaka/libp2p-rs?branch=wasi)",
  "libp2p-mplex 0.12.0 (git+https://github.com/tomaka/libp2p-rs?branch=wasi)",
  "libp2p-plaintext 0.12.0 (git+https://github.com/tomaka/libp2p-rs?branch=wasi)",
  "libp2p-swarm 0.2.0 (git+https://github.com/tomaka/libp2p-rs?branch=wasi)",
- "loader 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-interface-interface 0.1.0",
+ "nametbd-loader-interface 0.1.0",
+ "nametbd-syscalls-interface 0.1.0",
+ "nametbd-tcp-interface 0.1.0",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
- "tcp 0.1.0",
 ]
 
 [[package]]
@@ -713,14 +705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loader"
-version = "0.1.0"
-dependencies = [
- "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +749,63 @@ dependencies = [
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-interface-interface"
+version = "0.1.0"
+dependencies = [
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-loader-interface"
+version = "0.1.0"
+dependencies = [
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-syscalls-interface"
+version = "0.1.0"
+dependencies = [
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "send_wrapper 0.2.0 (git+https://github.com/tomaka/send_wrapper?branch=patch-1)",
+]
+
+[[package]]
+name = "nametbd-tcp-interface"
+version = "0.1.0"
+dependencies = [
+ "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-vulkan-interface"
+version = "0.1.0"
+dependencies = [
+ "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-window-interface"
+version = "0.1.0"
+dependencies = [
+ "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1321,28 +1362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syscalls"
-version = "0.1.0"
-dependencies = [
- "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "send_wrapper 0.2.0 (git+https://github.com/tomaka/send_wrapper?branch=patch-1)",
-]
-
-[[package]]
-name = "tcp"
-version = "0.1.0"
-dependencies = [
- "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,25 +1503,15 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "vulkan"
-version = "0.1.0"
-dependencies = [
- "hashbrown 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
- "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "vulkan-triangle"
 version = "0.1.0"
 dependencies = [
- "syscalls 0.1.0",
+ "nametbd-syscalls-interface 0.1.0",
+ "nametbd-vulkan-interface 0.1.0",
+ "nametbd-window-interface 0.1.0",
  "vk-sys 0.4.0 (git+https://github.com/tomaka/vulkano?branch=wasm)",
- "vulkan 0.1.0",
  "vulkano 0.14.0 (git+https://github.com/tomaka/vulkano?branch=wasm)",
  "vulkano-shaders 0.14.0 (git+https://github.com/tomaka/vulkano?branch=wasm)",
- "window 0.1.0",
 ]
 
 [[package]]
@@ -1655,15 +1664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "window"
-version = "0.1.0"
-dependencies = [
- "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscalls 0.1.0",
-]
 
 [[package]]
 name = "xml-rs"

--- a/modules/ipfs/Cargo.toml
+++ b/modules/ipfs/Cargo.toml
@@ -8,15 +8,15 @@ publish = false
 [dependencies]
 futures-preview = { version = "0.3.0-alpha.18", features = ["compat", "io-compat"] }
 futures01 = { package = "futures", version = "0.1" }
-interface = { path = "../../interfaces/interface" }
 libp2p-core = { git = "https://github.com/tomaka/libp2p-rs", branch = "wasi" }
 libp2p-kad = { git = "https://github.com/tomaka/libp2p-rs", branch = "wasi" }
 libp2p-mplex = { git = "https://github.com/tomaka/libp2p-rs", branch = "wasi" }
 #libp2p-secio = { git = "https://github.com/tomaka/libp2p-rs", branch = "wasi" }
 libp2p-plaintext = { git = "https://github.com/tomaka/libp2p-rs", branch = "wasi" }
 libp2p-swarm = { git = "https://github.com/tomaka/libp2p-rs", branch = "wasi" }
-loader = { path = "../../interfaces/loader" }
 log = "0.4"
+nametbd-interface-interface = { path = "../../interfaces/interface" }
+nametbd-loader-interface = { path = "../../interfaces/loader" }
+nametbd-syscalls-interface = { path = "../../interfaces/syscalls" }
+nametbd-tcp-interface = { path = "../../interfaces/tcp" }
 parity-scale-codec = "1.0.5"
-syscalls = { path = "../../interfaces/syscalls" }
-tcp = { path = "../../interfaces/tcp" }

--- a/modules/ipfs/src/main.rs
+++ b/modules/ipfs/src/main.rs
@@ -17,17 +17,17 @@ use futures::prelude::*;
 use parity_scale_codec::DecodeAll;
 
 fn main() {
-    syscalls::block_on(async move {
-        interface::register_interface(loader::ffi::INTERFACE).await.unwrap();
+    nametbd_syscalls_interface::block_on(async move {
+        nametbd_interface_interface::register_interface(nametbd_loader_interface::ffi::INTERFACE).await.unwrap();
 
         loop {
-            let msg = syscalls::next_interface_message().await;
-            assert_eq!(msg.interface, loader::ffi::INTERFACE);
-            let msg_data = loader::ffi::LoaderMessage::decode_all(&msg.actual_data).unwrap();
-            let loader::ffi::LoaderMessage::Load(hash_to_load) = msg_data;
+            let msg = nametbd_syscalls_interface::next_interface_message().await;
+            assert_eq!(msg.interface, nametbd_loader_interface::ffi::INTERFACE);
+            let msg_data = nametbd_loader_interface::ffi::LoaderMessage::decode_all(&msg.actual_data).unwrap();
+            let nametbd_loader_interface::ffi::LoaderMessage::Load(hash_to_load) = msg_data;
             println!("received message: {:?}", hash_to_load);
             let data = include_bytes!("../../target/wasm32-wasi/release/preloaded.wasm");
-            syscalls::emit_answer(msg.message_id.unwrap(), &loader::ffi::LoadResponse {
+            nametbd_syscalls_interface::emit_answer(msg.message_id.unwrap(), &nametbd_loader_interface::ffi::LoadResponse {
                 result: Ok(data.to_vec())
             });
         }

--- a/modules/ipfs/src/tcp_transport.rs
+++ b/modules/ipfs/src/tcp_transport.rs
@@ -44,7 +44,7 @@ impl TcpConfig {
 }
 
 impl Transport for TcpConfig {
-    type Output = Compat<tcp::TcpStream>;
+    type Output = Compat<nametbd_tcp_interface::TcpStream>;
     type Error = io::Error;
     type Listener = Box<dyn futures01::Stream<Item = ListenerEvent<Self::ListenerUpgrade>, Error = Self::Error> + Send>;
     type ListenerUpgrade = futures01::future::FutureResult<Self::Output, Self::Error>;
@@ -67,7 +67,7 @@ impl Transport for TcpConfig {
             };
 
         debug!("Dialing {}", addr);
-        Ok(Box::new(Future::map(Compat::new(Box::pin(tcp::TcpStream::connect(&socket_addr).map(Ok))), |f| Compat::new(f))))
+        Ok(Box::new(Future::map(Compat::new(Box::pin(nametbd_tcp_interface::TcpStream::connect(&socket_addr).map(Ok))), |f| Compat::new(f))))
     }
 }
 

--- a/modules/vulkan-triangle/Cargo.toml
+++ b/modules/vulkan-triangle/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
+nametbd-syscalls-interface = { path = "../../interfaces/syscalls" }
+nametbd-vulkan-interface = { path = "../../interfaces/vulkan" }
+nametbd-window-interface = { path = "../../interfaces/window" }
 # TODO: upstream the changes
-syscalls = { path = "../../interfaces/syscalls" }
 vulkano = { git = "https://github.com/tomaka/vulkano", branch = "wasm" }
 vulkano-shaders = { git = "https://github.com/tomaka/vulkano", branch = "wasm" }
-vulkan = { path = "../../interfaces/vulkan" }
 vk-sys = { git = "https://github.com/tomaka/vulkano", branch = "wasm" }
-window = { path = "../../interfaces/window" }

--- a/modules/vulkan-triangle/src/main.rs
+++ b/modules/vulkan-triangle/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
         unsafe impl vulkano::instance::loader::Loader for MyLoader {
             fn get_instance_proc_addr(&self, instance: vk_sys::Instance, name: *const std::os::raw::c_char) -> extern "system" fn() {
                 unsafe {
-                    vulkan::vkGetInstanceProcAddr(instance, name as *const _)
+                    nametbd_vulkan_interface::vkGetInstanceProcAddr(instance, name as *const _)
                 }
             }
         }
@@ -86,7 +86,7 @@ fn main() {
     let mut events_loop = EventsLoop::new();
     let surface = WindowBuilder::new().build_vk_surface(&events_loop, instance.clone()).unwrap();
     let window = surface.window();*/
-    let window = syscalls::block_on(window::Window::open()).unwrap();
+    let window = nametbd_syscalls_interface::block_on(nametbd_window_interface::Window::open()).unwrap();
 
     // The next step is to choose which GPU queue will execute our draw commands.
     //


### PR DESCRIPTION
Renames all the crates with the name `nametbd`. For example: `nametbd-tcp-interface`, `nametbd-wasi-hosted`, `nametbd-core`, ...

The `nametbd` is *actually* because the name is not determined, and not an ironic way to name the project. I can later do a `sed/nametbd/something/` to easily change that.