### PR TITLE
Move extrinsics registration from ipc to processes

### DIFF
--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -198,7 +198,8 @@ pub struct CoreThread<'a, T> {
     marker: PhantomData<T>,
 }
 
-impl<T: Clone> Core<T> {        // TODO: figure out borrowing issues and remove that Clone
+impl<T: Clone> Core<T> {
+    // TODO: figure out borrowing issues and remove that Clone
     /// Initialies a new `Core`.
     pub fn new() -> CoreBuilder<T> {
         let root_interface_id = "";
@@ -625,7 +626,9 @@ impl<T: Clone> Core<T> {        // TODO: figure out borrowing issues and remove 
             messages_queue: VecDeque::new(),
         };
 
-        let process = self.processes.execute(module, proc_metadata, Thread::ReadyToRun)?;
+        let process = self
+            .processes
+            .execute(module, proc_metadata, Thread::ReadyToRun)?;
 
         Ok(CoreProcess {
             process,

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -945,7 +945,7 @@ mod tests {
                 params,
             } => {
                 assert_eq!(thread.pid(), expected_pid);
-                assert_eq!(*extrinsic, 639);
+                assert_eq!(extrinsic, 639);
                 assert!(params.is_empty());
                 thread.id()
             }

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -28,22 +28,10 @@ use parity_scale_codec::Encode;
 /// Handles scheduling processes and inter-process communications.
 pub struct Core<T> {
     /// List of running processes.
-    processes: processes::ProcessesCollection<Process, Thread>,
+    processes: processes::ProcessesCollection<Extrinsic<T>, Process, Thread>,
 
     /// For each interface, which program is fulfilling it.
     interfaces: HashMap<[u8; 32], InterfaceHandler>,
-
-    /// List of functions that processes can call.
-    /// The key of this map is an arbitrary `usize` that we pass to the WASM interpreter.
-    /// This field is never modified after the `Core` is created.
-    // TODO: move extrinsics system somewhere else? it's not really IPC
-    extrinsics: HashMap<usize, Extrinsic<T>>,
-
-    /// Map used to resolve imports when starting a process.
-    /// For each module and function name, stores the signature and an arbitrary usize that
-    /// corresponds to the entry in `extrinsics`.
-    /// This field is never modified after the `Core` is created.
-    extrinsics_id_assign: HashMap<(Cow<'static, str>, Cow<'static, str>), (usize, Signature)>,
 
     /// Pool of identifiers for messages.
     message_id_pool: IdPool,
@@ -84,10 +72,8 @@ enum Extrinsic<T> {
 pub struct CoreBuilder<T> {
     /// See the corresponding field in `Core`.
     interfaces: HashMap<[u8; 32], InterfaceHandler>,
-    /// See the corresponding field in `Core`.
-    extrinsics: HashMap<usize, Extrinsic<T>>,
-    /// See the corresponding field in `Core`.
-    extrinsics_id_assign: HashMap<(Cow<'static, str>, Cow<'static, str>), (usize, Signature)>,
+    /// Builder for the [`processes`][Core::processes] field in `Core`.
+    inner_builder: processes::ProcessesCollectionBuilder<Extrinsic<T>>,
 }
 
 /// Outcome of calling [`run`](Core::run).
@@ -103,7 +89,7 @@ pub enum CoreRunOutcome<'a, T> {
     },
     ThreadWaitExtrinsic {
         thread: CoreThread<'a, T>,
-        extrinsic: &'a T,
+        extrinsic: T,
         params: Vec<wasmi::RuntimeValue>,
     },
     InterfaceMessage {
@@ -123,7 +109,7 @@ pub enum CoreRunOutcome<'a, T> {
 
 /// Because of lifetime issues, this is the same as `CoreRunOutcome` but that holds `Pid`s instead
 /// of `CoreProcess`es.
-enum CoreRunOutcomeInner {
+enum CoreRunOutcomeInner<T> {
     ProgramFinished {
         process: Pid,
         return_value: Option<wasmi::RuntimeValue>, // TODO: force to i32?
@@ -134,7 +120,7 @@ enum CoreRunOutcomeInner {
     },
     ThreadWaitExtrinsic {
         thread: ThreadId,
-        extrinsic: usize,
+        extrinsic: T,
         params: Vec<wasmi::RuntimeValue>,
     },
     InterfaceMessage {
@@ -212,42 +198,39 @@ pub struct CoreThread<'a, T> {
     marker: PhantomData<T>,
 }
 
-impl<T> Core<T> {
+impl<T: Clone> Core<T> {        // TODO: figure out borrowing issues and remove that Clone
     /// Initialies a new `Core`.
     pub fn new() -> CoreBuilder<T> {
-        let builder = CoreBuilder {
-            interfaces: Default::default(),
-            extrinsics: Default::default(),
-            extrinsics_id_assign: Default::default(),
-        };
-
         let root_interface_id = "";
 
-        builder
-            .with_extrinsic_inner(
-                root_interface_id.clone(),
-                "next_message",
-                sig!((I32, I32, I32, I32, I32) -> I32),
-                Extrinsic::NextMessage,
-            )
-            .with_extrinsic_inner(
-                root_interface_id.clone(),
-                "emit_message",
-                sig!((I32, I32, I32, I32, I32) -> I32),
-                Extrinsic::EmitMessage,
-            )
-            .with_extrinsic_inner(
-                root_interface_id.clone(),
-                "emit_answer",
-                sig!((I32, I32, I32) -> I32),
-                Extrinsic::EmitAnswer,
-            )
-            .with_extrinsic_inner(
-                root_interface_id.clone(),
-                "cancel_message",
-                sig!((I32) -> I32),
-                Extrinsic::CancelMessage,
-            )
+        CoreBuilder {
+            interfaces: Default::default(),
+            inner_builder: processes::ProcessesCollection::builder()
+                .with_extrinsic(
+                    root_interface_id.clone(),
+                    "next_message",
+                    sig!((I32, I32, I32, I32, I32) -> I32),
+                    Extrinsic::NextMessage,
+                )
+                .with_extrinsic(
+                    root_interface_id.clone(),
+                    "emit_message",
+                    sig!((I32, I32, I32, I32, I32) -> I32),
+                    Extrinsic::EmitMessage,
+                )
+                .with_extrinsic(
+                    root_interface_id.clone(),
+                    "emit_answer",
+                    sig!((I32, I32, I32) -> I32),
+                    Extrinsic::EmitAnswer,
+                )
+                .with_extrinsic(
+                    root_interface_id.clone(),
+                    "cancel_message",
+                    sig!((I32) -> I32),
+                    Extrinsic::CancelMessage,
+                ),
+        }
     }
 
     /// Run the core once.
@@ -276,10 +259,7 @@ impl<T> Core<T> {
                         thread: self.processes.thread_by_id(thread).unwrap(),
                         marker: PhantomData,
                     },
-                    extrinsic: match self.extrinsics.get(&extrinsic).unwrap() {
-                        Extrinsic::External(ref token) => token,
-                        _ => panic!(),
-                    },
+                    extrinsic,
                     params,
                 },
                 CoreRunOutcomeInner::InterfaceMessage {
@@ -309,7 +289,7 @@ impl<T> Core<T> {
     /// Because of lifetime issues, we return an enum that holds `Pid`s instead of `CoreProcess`es.
     /// Then `run` does the conversion in order to have a good API.
     // TODO: make multithreaded
-    fn run_inner(&mut self) -> CoreRunOutcomeInner {
+    fn run_inner(&mut self) -> CoreRunOutcomeInner<T> {
         match self.processes.run() {
             processes::RunOneOutcome::ProcessFinished { pid, value, .. } => {
                 // TODO: must clean up all the interfaces stuff
@@ -328,14 +308,12 @@ impl<T> Core<T> {
                 params,
             } => {
                 debug_assert_eq!(*thread.user_data(), Thread::ReadyToRun);
-
-                // TODO: check params against signature with a debug_assert
-                match self.extrinsics.get(&id).unwrap() {
-                    Extrinsic::External(_) => {
+                match id {
+                    Extrinsic::External(ext) => {
                         *thread.user_data() = Thread::ExtrinsicWait;
                         return CoreRunOutcomeInner::ThreadWaitExtrinsic {
                             thread: thread.id(),
-                            extrinsic: id,
+                            extrinsic: ext.clone(),
                             params,
                         };
                     }
@@ -599,7 +577,7 @@ impl<T> Core<T> {
         message_id: u64,
         response: &[u8],
         answerer_pid: Option<Pid>,
-    ) -> Option<CoreRunOutcomeInner> {
+    ) -> Option<CoreRunOutcomeInner<T>> {
         let actual_message = nametbd_syscalls_interface::ffi::Message::Response(
             nametbd_syscalls_interface::ffi::ResponseMessage {
                 message_id,
@@ -647,31 +625,7 @@ impl<T> Core<T> {
             messages_queue: VecDeque::new(),
         };
 
-        let extrinsics_id_assign = &mut self.extrinsics_id_assign;
-
-        let process = self.processes.execute(
-            module,
-            proc_metadata,
-            Thread::ReadyToRun,
-            move |interface, function, obtained_signature| {
-                if let Some((index, expected_signature)) =
-                    extrinsics_id_assign.get(&(interface.into(), function.into()))
-                {
-                    if expected_signature.matches_wasmi(obtained_signature) {
-                        return Ok(*index);
-                    } else {
-                        // TODO: remove this println?
-                        // TODO: way to report the signature mismatch?
-                        println!(
-                            "signature mismatch for {:?}:{:?}; expected={:?}; obtained={:?}",
-                            interface, function, expected_signature, obtained_signature
-                        );
-                    }
-                }
-
-                Err(())
-            },
-        )?;
+        let process = self.processes.execute(module, proc_metadata, Thread::ReadyToRun)?;
 
         Ok(CoreProcess {
             process,
@@ -746,37 +700,18 @@ impl<T> CoreBuilder<T> {
     /// Registers a function that processes can call.
     // TODO: more docs
     pub fn with_extrinsic(
-        self,
+        mut self,
         interface: impl Into<Cow<'static, str>>,
         f_name: impl Into<Cow<'static, str>>,
         signature: Signature,
         token: impl Into<T>,
     ) -> Self {
-        self.with_extrinsic_inner(
+        self.inner_builder = self.inner_builder.with_extrinsic(
             interface,
             f_name,
             signature,
             Extrinsic::External(token.into()),
-        )
-    }
-
-    /// Inner implementation of `with_extrinsic`.
-    fn with_extrinsic_inner(
-        mut self,
-        interface: impl Into<Cow<'static, str>>,
-        f_name: impl Into<Cow<'static, str>>,
-        signature: Signature,
-        extrinsic: Extrinsic<T>,
-    ) -> Self {
-        // TODO: panic if we already have it
-        let interface = interface.into();
-        let f_name = f_name.into();
-
-        let index = self.extrinsics.len();
-        debug_assert!(!self.extrinsics.contains_key(&index));
-        self.extrinsics_id_assign
-            .insert((interface, f_name), (index, signature));
-        self.extrinsics.insert(index, extrinsic);
+        );
         self
     }
 
@@ -792,17 +727,10 @@ impl<T> CoreBuilder<T> {
     }
 
     /// Turns the builder into a [`Core`].
-    pub fn build(mut self) -> Core<T> {
-        // We're not going to modify these fields ever again, so let's free some memory.
-        self.extrinsics.shrink_to_fit();
-        self.extrinsics_id_assign.shrink_to_fit();
-        debug_assert_eq!(self.extrinsics.len(), self.extrinsics_id_assign.len());
-
+    pub fn build(self) -> Core<T> {
         Core {
-            processes: processes::ProcessesCollection::new(),
+            processes: self.inner_builder.build(),
             interfaces: self.interfaces,
-            extrinsics: self.extrinsics,
-            extrinsics_id_assign: self.extrinsics_id_assign,
             message_id_pool: IdPool::new(),
             messages_to_answer: HashMap::default(),
         }

--- a/core/src/scheduler/processes.rs
+++ b/core/src/scheduler/processes.rs
@@ -16,7 +16,8 @@
 use crate::id_pool::IdPool;
 use crate::module::Module;
 use crate::scheduler::{vm, Pid};
-use alloc::vec::Vec;
+use crate::signature::Signature;
+use alloc::{borrow::Cow, vec::Vec};
 use core::fmt;
 use hashbrown::{
     hash_map::{DefaultHashBuilder, Entry, OccupiedEntry},
@@ -29,9 +30,9 @@ use rand::seq::SliceRandom as _;
 ///
 /// This struct handles interleaving processes execution.
 ///
-/// The generic parameters are "user data"s that are stored per process and per thread, and allows
-/// the user to put extra information associated to a process or a thread.
-pub struct ProcessesCollection<TPud, TTud> {
+/// The generic parameters `TPud` and `TTud` are "user data"s that are stored per process and per
+/// thread, and allows the user to put extra information associated to a process or a thread.
+pub struct ProcessesCollection<TExtr, TPud, TTud> {
     /// Allocations of process IDs.
     pid_pool: IdPool,
 
@@ -40,6 +41,25 @@ pub struct ProcessesCollection<TPud, TTud> {
 
     /// List of running processes.
     processes: HashMap<Pid, Process<TPud, TTud>>,
+
+    /// List of functions that processes can call.
+    /// The key of this map is an arbitrary `usize` that we pass to the WASM interpreter.
+    /// This field is never modified after the `ProcessesCollection` is created.
+    extrinsics: HashMap<usize, TExtr>,
+
+    /// Map used to resolve imports when starting a process.
+    /// For each module and function name, stores the signature and an arbitrary usize that
+    /// corresponds to the entry in `extrinsics`.
+    /// This field is never modified after the `Core` is created.
+    extrinsics_id_assign: HashMap<(Cow<'static, str>, Cow<'static, str>), (usize, Signature)>,
+}
+
+/// Prototype for a `ProcessesCollection` under construction.
+pub struct ProcessesCollectionBuilder<TExtr> {
+    /// See the corresponding field in `ProcessesCollection`.
+    extrinsics: HashMap<usize, TExtr>,
+    /// See the corresponding field in `ProcessesCollection`.
+    extrinsics_id_assign: HashMap<(Cow<'static, str>, Cow<'static, str>), (usize, Signature)>,
 }
 
 /// Identifier of a thread within the [`ProcessesCollection`].
@@ -90,7 +110,7 @@ pub struct ProcessesCollectionThread<'a, TPud, TTud> {
 
 /// Outcome of the [`run`](ProcessesCollection::run) function.
 #[derive(Debug)]
-pub enum RunOneOutcome<'a, TPud, TTud> {
+pub enum RunOneOutcome<'a, TExtr, TPud, TTud> {
     /// The main thread of a process has finished.
     ///
     /// The process no longer exists.
@@ -133,7 +153,7 @@ pub enum RunOneOutcome<'a, TPud, TTud> {
 
         /// Identifier of the function to call. Corresponds to the value provided at
         /// initialization when resolving imports.
-        id: usize,
+        id: &'a mut TExtr,
 
         /// Parameters of the function call.
         params: Vec<wasmi::RuntimeValue>,
@@ -167,16 +187,17 @@ pub enum RunOneOutcome<'a, TPud, TTud> {
 /// to grow again in the future. We therefore avoid that situation.
 const PROCESSES_MIN_CAPACITY: usize = 128;
 
-impl<TPud, TTud> ProcessesCollection<TPud, TTud> {
-    /// Creates a new empty collection.
-    pub fn new() -> Self {
-        ProcessesCollection {
-            pid_pool: IdPool::new(),
-            thread_id_pool: IdPool::new(),
-            processes: HashMap::with_capacity(PROCESSES_MIN_CAPACITY),
+impl<TExtr> ProcessesCollection<TExtr, (), ()> {
+    /// Creates a new builder.
+    pub fn builder() -> ProcessesCollectionBuilder<TExtr> {
+        ProcessesCollectionBuilder {
+            extrinsics: Default::default(),
+            extrinsics_id_assign: Default::default(),
         }
     }
+}
 
+impl<TExtr, TPud, TTud> ProcessesCollection<TExtr, TPud, TTud> {
     /// Creates a new process state machine from the given module.
     ///
     /// The closure is called for each import that the module has. It must assign a number to each
@@ -191,7 +212,6 @@ impl<TPud, TTud> ProcessesCollection<TPud, TTud> {
         module: &Module,
         proc_user_data: TPud,
         main_thread_user_data: TTud,
-        symbols: impl FnMut(&str, &str, &wasmi::Signature) -> Result<usize, ()>,
     ) -> Result<ProcessesCollectionProc<TPud, TTud>, vm::NewErr> {
         let main_thread_id = self.thread_id_pool.assign(); // TODO: check for duplicates
         let main_thread_data = Thread {
@@ -200,7 +220,31 @@ impl<TPud, TTud> ProcessesCollection<TPud, TTud> {
             value_back: Some(None),
         };
 
-        let state_machine = vm::ProcessStateMachine::new(module, main_thread_data, symbols)?;
+        let state_machine = {
+            let extrinsics_id_assign = &mut self.extrinsics_id_assign;
+            vm::ProcessStateMachine::new(
+                module,
+                main_thread_data, 
+                move |interface, function, obtained_signature| {
+                    if let Some((index, expected_signature)) =
+                        extrinsics_id_assign.get(&(interface.into(), function.into()))
+                    {
+                        if expected_signature.matches_wasmi(obtained_signature) {
+                            return Ok(*index);
+                        } else {
+                            // TODO: remove this println?
+                            // TODO: way to report the signature mismatch?
+                            println!(
+                                "signature mismatch for {:?}:{:?}; expected={:?}; obtained={:?}",
+                                interface, function, expected_signature, obtained_signature
+                            );
+                        }
+                    }
+
+                    Err(())
+                }
+            )?
+        };
 
         // We only modify `self` at the very end.
         let new_pid = self.pid_pool.assign();
@@ -221,7 +265,7 @@ impl<TPud, TTud> ProcessesCollection<TPud, TTud> {
     /// Runs one thread amongst the collection.
     ///
     /// Which thread is run is implementation-defined and no guarantee is made.
-    pub fn run(&mut self) -> RunOneOutcome<TPud, TTud> {
+    pub fn run(&mut self) -> RunOneOutcome<TExtr, TPud, TTud> {
         // We start by finding a thread in `self.processes` that is ready to run.
         let (mut process, thread_index): (OccupiedEntry<_, _, _>, usize) = {
             let mut entries = self.processes.iter_mut().collect::<Vec<_>>();
@@ -299,13 +343,17 @@ impl<TPud, TTud> ProcessesCollection<TPud, TTud> {
                 user_data: user_data.user_data,
                 value: return_value,
             },
-            Ok(vm::ExecOutcome::Interrupted { id, params, .. }) => RunOneOutcome::Interrupted {
-                thread: ProcessesCollectionThread {
-                    process,
-                    thread_index,
-                },
-                id,
-                params,
+            Ok(vm::ExecOutcome::Interrupted { id, params, .. }) => {
+                // TODO: check params against signature with a debug_assert
+                let extrinsic = self.extrinsics.get_mut(&id).unwrap();
+                RunOneOutcome::Interrupted {
+                    thread: ProcessesCollectionThread {
+                        process,
+                        thread_index,
+                    },
+                    id: extrinsic,
+                    params,
+                }
             },
             Ok(vm::ExecOutcome::Errored { error, .. }) => {
                 let (
@@ -371,9 +419,43 @@ impl<TPud, TTud> ProcessesCollection<TPud, TTud> {
     }
 }
 
-impl<TPud, TTud> Default for ProcessesCollection<TPud, TTud> {
-    fn default() -> Self {
-        Self::new()
+
+impl<TExtr> ProcessesCollectionBuilder<TExtr> {
+    /// Registers a function that processes can call.
+    // TODO: more docs
+    pub fn with_extrinsic(
+        mut self,
+        interface: impl Into<Cow<'static, str>>,
+        f_name: impl Into<Cow<'static, str>>,
+        signature: Signature,
+        token: impl Into<TExtr>,
+    ) -> Self {
+        // TODO: panic if we already have it
+        let interface = interface.into();
+        let f_name = f_name.into();
+
+        let index = self.extrinsics.len();
+        debug_assert!(!self.extrinsics.contains_key(&index));
+        self.extrinsics_id_assign
+            .insert((interface, f_name), (index, signature));
+        self.extrinsics.insert(index, token.into());
+        self
+    }
+
+    /// Turns the builder into a [`ProcessesCollection`].
+    pub fn build<TPud, TTud>(mut self) -> ProcessesCollection<TExtr, TPud, TTud> {
+        // We're not going to modify these fields ever again, so let's free some memory.
+        self.extrinsics.shrink_to_fit();
+        self.extrinsics_id_assign.shrink_to_fit();
+        debug_assert_eq!(self.extrinsics.len(), self.extrinsics_id_assign.len());
+
+        ProcessesCollection {
+            pid_pool: IdPool::new(),
+            thread_id_pool: IdPool::new(),
+            processes: HashMap::with_capacity(PROCESSES_MIN_CAPACITY),
+            extrinsics: self.extrinsics,
+            extrinsics_id_assign: self.extrinsics_id_assign,
+        }
     }
 }
 

--- a/core/src/scheduler/processes.rs
+++ b/core/src/scheduler/processes.rs
@@ -224,7 +224,7 @@ impl<TExtr, TPud, TTud> ProcessesCollection<TExtr, TPud, TTud> {
             let extrinsics_id_assign = &mut self.extrinsics_id_assign;
             vm::ProcessStateMachine::new(
                 module,
-                main_thread_data, 
+                main_thread_data,
                 move |interface, function, obtained_signature| {
                     if let Some((index, expected_signature)) =
                         extrinsics_id_assign.get(&(interface.into(), function.into()))
@@ -242,7 +242,7 @@ impl<TExtr, TPud, TTud> ProcessesCollection<TExtr, TPud, TTud> {
                     }
 
                     Err(())
-                }
+                },
             )?
         };
 
@@ -354,7 +354,7 @@ impl<TExtr, TPud, TTud> ProcessesCollection<TExtr, TPud, TTud> {
                     id: extrinsic,
                     params,
                 }
-            },
+            }
             Ok(vm::ExecOutcome::Errored { error, .. }) => {
                 let (
                     pid,
@@ -418,7 +418,6 @@ impl<TExtr, TPud, TTud> ProcessesCollection<TExtr, TPud, TTud> {
         })
     }
 }
-
 
 impl<TExtr> ProcessesCollectionBuilder<TExtr> {
     /// Registers a function that processes can call.

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -256,7 +256,8 @@ impl<TExtEx: Clone> System<TExtEx> {
     }
 }
 
-impl<TExtEx: Clone> SystemBuilder<TExtEx> {     // TODO: remove Clone once possible
+impl<TExtEx: Clone> SystemBuilder<TExtEx> {
+    // TODO: remove Clone once possible
     pub fn with_extrinsic(
         mut self,
         interface: impl Into<Cow<'static, str>>,

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -107,14 +107,14 @@ impl<TExtEx: Clone> System<TExtEx> {
                 }
                 CoreRunOutcome::ThreadWaitExtrinsic {
                     ref mut thread,
-                    extrinsic: external_token,
+                    ref extrinsic,
                     ref params,
                 } => {
                     let pid = thread.pid();
                     return SystemRunOutcome::ThreadWaitExtrinsic {
                         pid,
                         thread_id: thread.id(),
-                        extrinsic: external_token.clone(),
+                        extrinsic: extrinsic.clone(),
                         params: params.clone(),
                     };
                 }
@@ -256,7 +256,7 @@ impl<TExtEx: Clone> System<TExtEx> {
     }
 }
 
-impl<TExtEx> SystemBuilder<TExtEx> {
+impl<TExtEx: Clone> SystemBuilder<TExtEx> {     // TODO: remove Clone once possible
     pub fn with_extrinsic(
         mut self,
         interface: impl Into<Cow<'static, str>>,

--- a/hosted/wasi/src/lib.rs
+++ b/hosted/wasi/src/lib.rs
@@ -41,7 +41,10 @@ enum WasiExtrinsicInner {
 }
 
 /// Adds to the `SystemBuilder` the extrinsics required by WASI.
-pub fn register_extrinsics<T: From<WasiExtrinsic> + Clone>(system: SystemBuilder<T>) -> SystemBuilder<T> {      // TODO: remove Clone
+pub fn register_extrinsics<T: From<WasiExtrinsic> + Clone>(
+    system: SystemBuilder<T>,
+) -> SystemBuilder<T> {
+    // TODO: remove Clone
     system
         .with_extrinsic(
             "wasi_unstable",

--- a/hosted/wasi/src/lib.rs
+++ b/hosted/wasi/src/lib.rs
@@ -41,7 +41,7 @@ enum WasiExtrinsicInner {
 }
 
 /// Adds to the `SystemBuilder` the extrinsics required by WASI.
-pub fn register_extrinsics<T: From<WasiExtrinsic>>(system: SystemBuilder<T>) -> SystemBuilder<T> {
+pub fn register_extrinsics<T: From<WasiExtrinsic> + Clone>(system: SystemBuilder<T>) -> SystemBuilder<T> {      // TODO: remove Clone
     system
         .with_extrinsic(
             "wasi_unstable",


### PR DESCRIPTION
Instead of having `ipc.rs` keep track of the available extrinsics (i.e. functions that the WASM code can directly import and call), we move that to `processes.rs`.

The objective is to simplify a bit the code of `ipc.rs`.

From the point of view of `processes.rs`, there's no such thing as a message. All that this module is concerned about is calling functions that potentially put threads to sleep.
If we ever add some "meta-information" about an extrinsic (e.g. likelihood of thread being able to continue running, or something), then it makes sense for this to be in `processes.rs`.
