### PR TITLE
Add support for sleeping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ version = "0.1.0"
 dependencies = [
  "nametbd-syscalls-interface 0.1.0",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1041,6 +1042,24 @@ dependencies = [
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pin-project"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1670,6 +1689,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
+"checksum pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
 "checksum pin-project-lite 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f1f61fedcfa3b402e157c23e235b1ab6c30d52c219492c63504059e2bdd3408"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +714,7 @@ dependencies = [
 name = "nametbd-cli-kernel"
 version = "0.1.0"
 dependencies = [
+ "async-std 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nametbd-core 0.1.0",
  "nametbd-tcp-hosted 0.1.0",
@@ -834,6 +840,8 @@ dependencies = [
 name = "nametbd-time-hosted"
 version = "0.1.0"
 dependencies = [
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nametbd-time-interface 0.1.0",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1615,6 +1623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
 "checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
 "checksum futures-timer 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7946248e9429ff093345d3e8fdf4eb0f9b2d79091611c9c14f744971a6f8be45"
+"checksum futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"

--- a/hosted/cli/Cargo.toml
+++ b/hosted/cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+async-std = "1.0"
 futures = "0.3.1"
 nametbd-core = { path = "../../core" }
 nametbd-tcp-hosted = { path = "../tcp" }

--- a/hosted/cli/src/main.rs
+++ b/hosted/cli/src/main.rs
@@ -51,12 +51,12 @@ async fn async_main() {
                 pin_mut!(tcp);
                 pin_mut!(time);
                 let to_send = match future::select(tcp, time).await {
-                    future::Either::Accept((
-                        nametbd_tcp_hosted::TcpResponse::Open(msg_id, msg),
+                    future::Either::Left((
+                        nametbd_tcp_hosted::TcpResponse::Accept(msg_id, msg),
                         _,
                     )) => (msg_id, msg.encode()),
-                    future::Either::Listen((
-                        nametbd_tcp_hosted::TcpResponse::Open(msg_id, msg),
+                    future::Either::Left((
+                        nametbd_tcp_hosted::TcpResponse::Listen(msg_id, msg),
                         _,
                     )) => (msg_id, msg.encode()),
                     future::Either::Left((

--- a/hosted/cli/src/main.rs
+++ b/hosted/cli/src/main.rs
@@ -15,8 +15,9 @@
 
 #![deny(intra_doc_link_resolution_failure)]
 
-use futures::prelude::*;
+use futures::{channel::mpsc, pin_mut, prelude::*};
 use parity_scale_codec::{DecodeAll, Encode as _};
+use std::sync::Arc;
 
 fn main() {
     futures::executor::block_on(async_main());
@@ -30,12 +31,47 @@ async fn async_main() {
 
     let mut system =
         nametbd_wasi_hosted::register_extrinsics(nametbd_core::system::SystemBuilder::new())
+            .with_interface_handler(nametbd_time_interface::ffi::INTERFACE)
             .with_interface_handler(nametbd_tcp_interface::ffi::INTERFACE)
             .with_startup_process(module)
             .with_main_program([0; 32]) // TODO: just a test
             .build();
 
-    let tcp = nametbd_tcp_hosted::TcpState::new();
+    let time = Arc::new(nametbd_time_hosted::TimerHandler::new());
+    let tcp = Arc::new(nametbd_tcp_hosted::TcpState::new());
+
+    let mut to_answer_rx = {
+        let (mut to_answer_tx, to_answer_rx) = mpsc::channel(16);
+        let tcp = tcp.clone();
+        let time = time.clone();
+        async_std::task::spawn(async move {
+            loop {
+                let tcp = tcp.next_event();
+                let time = time.next_answer();
+                pin_mut!(tcp);
+                pin_mut!(time);
+                let to_send = match future::select(tcp, time).await {
+                    future::Either::Left((
+                        nametbd_tcp_hosted::TcpResponse::Open(msg_id, msg),
+                        _,
+                    )) => (msg_id, msg.encode()),
+                    future::Either::Left((
+                        nametbd_tcp_hosted::TcpResponse::Read(msg_id, msg),
+                        _,
+                    )) => (msg_id, msg.encode()),
+                    future::Either::Left((
+                        nametbd_tcp_hosted::TcpResponse::Write(msg_id, msg),
+                        _,
+                    )) => (msg_id, msg.encode()),
+                    future::Either::Right(((msg_id, bytes), _)) => (msg_id, bytes),
+                };
+                if to_answer_tx.send(to_send).await.is_err() {
+                    break;
+                }
+            }
+        });
+        to_answer_rx
+    };
 
     loop {
         let result = loop {
@@ -60,8 +96,9 @@ async fn async_main() {
                     interface,
                     message,
                 } if interface == nametbd_time_interface::ffi::INTERFACE => {
-                    let answer = nametbd_time_hosted::time_message(&message);
-                    system.answer_message(message_id.unwrap(), &answer);
+                    if let Some(answer) = time.time_message(message_id, &message) {
+                        system.answer_message(message_id.unwrap(), &answer);
+                    }
                     continue;
                 }
                 nametbd_core::system::SystemRunOutcome::InterfaceMessage {
@@ -78,20 +115,16 @@ async fn async_main() {
                 other => break other,
             };
 
-            let event = if only_poll {
-                match tcp.next_event().now_or_never() {
+            let (msg_to_respond, response_bytes) = if only_poll {
+                match to_answer_rx.next().now_or_never() {
                     Some(e) => e,
                     None => continue,
                 }
             } else {
-                tcp.next_event().await
-            };
+                to_answer_rx.next().await
+            }
+            .unwrap();
 
-            let (msg_to_respond, response_bytes) = match event {
-                nametbd_tcp_hosted::TcpResponse::Open(msg_id, msg) => (msg_id, msg.encode()),
-                nametbd_tcp_hosted::TcpResponse::Read(msg_id, msg) => (msg_id, msg.encode()),
-                nametbd_tcp_hosted::TcpResponse::Write(msg_id, msg) => (msg_id, msg.encode()),
-            };
             system.answer_message(msg_to_respond, &response_bytes);
         };
 

--- a/hosted/kernel/src/main.rs
+++ b/hosted/kernel/src/main.rs
@@ -73,7 +73,7 @@ async fn async_main(
 
     let mut system =
         nametbd_wasi_hosted::register_extrinsics(nametbd_core::system::SystemBuilder::new())
-            .with_interface_handler(nametbd_time_interface::ffi::INTERFACE)
+            // TODO: restore this .with_interface_handler(nametbd_time_interface::ffi::INTERFACE)
             .with_interface_handler(nametbd_tcp_interface::ffi::INTERFACE)
             .with_interface_handler(nametbd_vulkan_interface::INTERFACE)
             .with_interface_handler(nametbd_window_interface::ffi::INTERFACE)
@@ -121,6 +121,7 @@ async fn async_main(
                     tcp.handle_message(message_id, message).await;
                     continue;
                 }
+                /* TODO: restore this
                 nametbd_core::system::SystemRunOutcome::InterfaceMessage {
                     message_id,
                     interface,
@@ -129,7 +130,7 @@ async fn async_main(
                     let answer = nametbd_time_hosted::time_message(&message);
                     system.answer_message(message_id.unwrap(), &answer);
                     continue;
-                }
+                }*/
                 nametbd_core::system::SystemRunOutcome::InterfaceMessage {
                     message_id,
                     interface,

--- a/hosted/time/Cargo.toml
+++ b/hosted/time/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
+futures = "0.3.0"
+futures-timer = "2.0"
 nametbd-time-interface = { path = "../../interfaces/time" }
 parity-scale-codec = "1.0.5"
 lazy_static = "1.4"

--- a/hosted/time/src/lib.rs
+++ b/hosted/time/src/lib.rs
@@ -15,16 +15,85 @@
 
 //! Implements the time interface.
 
+use futures::{prelude::*, channel::mpsc, lock::Mutex, stream::FuturesUnordered};
+use futures_timer::Delay;
 use nametbd_time_interface::ffi::TimeMessage;
 use parity_scale_codec::{DecodeAll, Encode as _};
-use std::time::{Duration, Instant, SystemTime};
+use std::{convert::TryFrom, pin::Pin, time::{Duration, Instant, SystemTime}};
 
-/// Processes a message on the `time` interface, and returns the answer send to back.
-pub fn time_message(message: &[u8]) -> Vec<u8> {
-    match TimeMessage::decode_all(&message).unwrap() {
-        // TODO: don't unwrap
-        TimeMessage::GetMonotonic => monotonic_clock().encode(),
-        TimeMessage::GetSystem => system_clock().encode(),
+/// State machine for `time` interface messages handling.
+pub struct TimerHandler {
+    /// Accessed only by `next_event`.
+    inner: Mutex<TimerHandlerInner>,
+    /// Send on this channel the new timers to insert in [`TimerHandlerInner::timers`].
+    new_timer_tx: mpsc::UnboundedSender<(Delay, u64)>,
+}
+
+/// Separate struct behind a mutex.
+struct TimerHandlerInner {
+    /// Stream of message IDs to answer.
+    timers: FuturesUnordered<Pin<Box<dyn Future<Output = u64> + Send>>>,   // TODO: meh for boxing
+    /// Receiving side of [`TimerHandler::new_timer_tx`].
+    new_timer_rx: mpsc::UnboundedReceiver<(Delay, u64)>,
+}
+
+impl TimerHandler {
+    /// Initializes the new state machine for timers.
+    pub fn new() -> TimerHandler {
+        let (new_timer_tx, new_timer_rx) = mpsc::unbounded();
+
+        TimerHandler {
+            inner: Mutex::new(TimerHandlerInner {
+                timers: {
+                    let timers = FuturesUnordered::<Pin<Box<dyn Future<Output = u64> + Send>>>::new();
+                    // TODO: ugh; pushing a never-ending future, otherwise we get a permanent `None` when polling
+                    timers.push(Box::pin(async move { loop { futures::pending!() } }));
+                    timers
+                },
+                new_timer_rx,
+            }),
+            new_timer_tx,
+        }
+    }
+
+    /// Processes a message on the `time` interface, and optionally returns an answer to
+    /// immediately send  back.
+    pub fn time_message(&self, message_id: Option<u64>, message: &[u8]) -> Option<Vec<u8>> {
+        match TimeMessage::decode_all(&message).unwrap() {
+            // TODO: don't unwrap
+            TimeMessage::GetMonotonic => Some(monotonic_clock().encode()),
+            TimeMessage::GetSystem => Some(system_clock().encode()),
+            TimeMessage::WaitMonotonic(until) => {
+                match until.checked_sub(monotonic_clock()) {
+                    None => Some(().encode()),
+                    Some(dur_from_now) => {
+                        let dur = Duration::from_nanos(u64::try_from(dur_from_now).unwrap_or(u64::max_value()));
+                        self.new_timer_tx.unbounded_send((Delay::new(dur), message_id.unwrap())).unwrap();
+                        None
+                    }
+                }
+            },
+        }
+    }
+
+    /// Returns the next message to answer, and the message to send back.
+    pub async fn next_answer(&self) -> (u64, Vec<u8>) {
+        let mut inner = self.inner.lock().await;
+        let inner = &mut *inner;
+
+        loop {
+            match future::select(inner.timers.next(), inner.new_timer_rx.next()).await {
+                future::Either::Left((Some(message_id), _)) => return (message_id, ().encode()),
+                future::Either::Right((Some((new_delay, message_id)), _)) => {
+                    inner.timers.push(Box::pin(async move {
+                        new_delay.await;
+                        message_id
+                    }));
+                },
+                future::Either::Left((None, _)) => unreachable!(),
+                future::Either::Right((None, _)) => unreachable!(),
+            }
+        }
     }
 }
 

--- a/interfaces/time/Cargo.toml
+++ b/interfaces/time/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 nametbd-syscalls-interface = { path = "../syscalls" }
 parity-scale-codec = { version = "1.0.5", features = ["derive"] }
+pin-project = "0.4.6"

--- a/interfaces/time/src/delay.rs
+++ b/interfaces/time/src/delay.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Instant, monotonic_wait_until};
+use std::{future::Future, pin::Pin, task::Context, task::Poll, time::Duration};
+
+/// Mimics the API of `futures_timer::Delay`.
+#[pin_project::pin_project]
+pub struct Delay {
+    when: Instant,
+    inner: Pin<Box<dyn Future<Output = ()> + Send>>,
+}
+
+impl Delay {
+    pub fn new(dur: Duration) -> Delay {
+        Delay::new_at(Instant::now() + dur)
+    }
+
+    pub fn new_at(at: Instant) -> Delay {
+        Delay {
+            when: at,
+            inner: Box::pin(monotonic_wait_until(at.inner)),
+        }
+    }
+
+    pub fn when(&self) -> Instant {
+        self.when
+    }
+
+    pub fn reset(&mut self, at: Instant) {
+        *self = Delay::new_at(at);
+    }
+}
+
+impl Future for Delay {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let this = self.project();
+        Future::poll(this.inner.as_mut(), cx)
+    }
+}

--- a/interfaces/time/src/delay.rs
+++ b/interfaces/time/src/delay.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Instant, monotonic_wait_until};
+use crate::{monotonic_wait_until, Instant};
 use std::{future::Future, pin::Pin, task::Context, task::Poll, time::Duration};
 
 /// Mimics the API of `futures_timer::Delay`.

--- a/interfaces/time/src/ffi.rs
+++ b/interfaces/time/src/ffi.rs
@@ -27,4 +27,6 @@ pub enum TimeMessage {
     GetMonotonic,
     /// Must respond with a `u128`.
     GetSystem,
+    /// Send response when the monotonic clock reaches this value. Responds with nothing (`()`).
+    WaitMonotonic(u128),
 }

--- a/interfaces/time/src/instant.rs
+++ b/interfaces/time/src/instant.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::monotonic_clock;
+use std::{convert::TryFrom, ops::Add, ops::Sub, time::Duration};
+
+/// Mimics the API of `std::time::Instant`, except that it works.
+///
+/// > **Note**: This struct should be removed in the future, as `std::time::Instant` should work
+/// >           when compiling to WASI.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Instant {
+    pub(crate) inner: u128,
+}
+
+impl Instant {
+    pub fn now() -> Instant {
+        let val = nametbd_syscalls_interface::block_on(monotonic_clock());
+        Instant { inner: val }
+    }
+
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        *self - earlier
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        Instant::now() - *self
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    fn add(self, other: Duration) -> Instant {
+        let new_val = self.inner + other.as_nanos();
+        Instant { inner: new_val }
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    fn sub(self, other: Duration) -> Instant {
+        let new_val = self.inner - other.as_nanos();
+        Instant { inner: new_val }
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    fn sub(self, other: Instant) -> Duration {
+        let ns = self.inner - other.inner;
+        // TODO: not great to unwrap, but we don't care
+        Duration::from_nanos(u64::try_from(ns).unwrap())
+    }
+}

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -19,6 +19,11 @@
 
 use std::time::Duration;
 
+pub use self::delay::Delay;
+pub use self::instant::Instant;
+
+mod delay;
+mod instant;
 pub mod ffi;
 
 /// Returns the number of nanoseconds since an arbitrary point in time in the past.

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -23,8 +23,8 @@ pub use self::delay::Delay;
 pub use self::instant::Instant;
 
 mod delay;
-mod instant;
 pub mod ffi;
+mod instant;
 
 /// Returns the number of nanoseconds since an arbitrary point in time in the past.
 pub async fn monotonic_clock() -> u128 {

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -17,6 +17,8 @@
 
 #![deny(intra_doc_link_resolution_failure)]
 
+use std::time::Duration;
+
 pub mod ffi;
 
 /// Returns the number of nanoseconds since an arbitrary point in time in the past.
@@ -33,4 +35,23 @@ pub async fn system_clock() -> u128 {
     nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
         .await
         .unwrap()
+}
+
+/// Returns a `Future` that yields when the monotonic clock reaches this value.
+pub async fn monotonic_wait_until(until: u128) {
+    let msg = ffi::TimeMessage::WaitMonotonic(until);
+    nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+        .await
+        .unwrap()
+}
+
+/// Returns a `Future` that outputs after `duration` has elapsed.
+pub async fn monotonic_wait(duration: Duration) {
+    let dur_nanos = u128::from(duration.as_secs())
+        .saturating_mul(1_000_000_000)
+        .saturating_add(u128::from(duration.subsec_nanos()));
+
+    // TODO: meh for two syscalls
+    let now = monotonic_clock().await;
+    monotonic_wait_until(now.saturating_add(dur_nanos)).await;
 }

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "nametbd-loader-interface 0.1.0",
  "nametbd-syscalls-interface 0.1.0",
  "nametbd-tcp-interface 0.1.0",
+ "nametbd-time-interface 0.1.0",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -806,6 +807,14 @@ name = "nametbd-tcp-interface"
 version = "0.1.0"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-time-interface"
+version = "0.1.0"
+dependencies = [
  "nametbd-syscalls-interface 0.1.0",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -817,6 +817,7 @@ version = "0.1.0"
 dependencies = [
  "nametbd-syscalls-interface 0.1.0",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -940,6 +941,24 @@ dependencies = [
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pin-project"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pin-utils"
@@ -1798,6 +1817,8 @@ dependencies = [
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
+"checksum pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"

--- a/modules/ipfs/Cargo.toml
+++ b/modules/ipfs/Cargo.toml
@@ -19,4 +19,5 @@ nametbd-interface-interface = { path = "../../interfaces/interface" }
 nametbd-loader-interface = { path = "../../interfaces/loader" }
 nametbd-syscalls-interface = { path = "../../interfaces/syscalls" }
 nametbd-tcp-interface = { path = "../../interfaces/tcp" }
+nametbd-time-interface = { path = "../../interfaces/time" }
 parity-scale-codec = "1.0.5"

--- a/modules/ipfs/src/main.rs
+++ b/modules/ipfs/src/main.rs
@@ -16,12 +16,15 @@
 use futures::prelude::*;
 use ipfs::{Network, NetworkEvent};
 use parity_scale_codec::DecodeAll;
+use std::time::Duration;
 
 fn main() {
     nametbd_syscalls_interface::block_on(async_main())
 }
 
 async fn async_main() {
+    nametbd_time_interface::monotonic_wait(Duration::from_secs(5)).await;
+
     nametbd_interface_interface::register_interface(nametbd_loader_interface::ffi::INTERFACE)
         .await
         .unwrap();


### PR DESCRIPTION
Adds support for timers.
This works by having a message which receives an empty response after a certain time has elapsed.

The `nametbd-time-hosted` crate was therefore refactored.