### PR TITLE
Add a hello world for the freestanding kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust
-      env:
-        CC: clang-9
     steps:
     - uses: actions/checkout@v1
     - name: Download WASM modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust
+      env:
+        CC: clang-9
     steps:
     - uses: actions/checkout@v1
     - name: Install Rust
@@ -63,6 +65,14 @@ jobs:
         toolchain: stable
         target: wasm32-wasi
         override: true
+    - name: Install a recent version of Clang
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+        echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" >> /etc/apt/sources.list
+        apt-get update
+        apt-get install -y clang-9
+    - name: Install CMake
+      run: apt-get install -y cmake
     - name: Install Vulkan
       run: |
         apt-get update
@@ -98,6 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust
+      env:
+        CC: clang-9
     steps:
     - uses: actions/checkout@v1
     - name: Download WASM modules
@@ -130,6 +142,8 @@ jobs:
         toolchain: nightly
         target: wasm32-wasi
         override: true
+    - name: Install wasm32-unknown-unknown
+      run: rustup target add wasm32-unknown-unknown
     - name: Install rust-src
       run: rustup component add rust-src
     - name: Build core for no_std platform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         CC: clang-9
     steps:
     - uses: actions/checkout@v1
-    - name: Install Rust nightly
+    - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -57,6 +57,12 @@ jobs:
       image: rust
     steps:
     - uses: actions/checkout@v1
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-wasi
+        override: true
     - name: Install Vulkan
       run: |
         apt-get update
@@ -122,6 +128,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
+        target: wasm32-wasi
         override: true
     - name: Install rust-src
       run: rustup component add rust-src

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "nametbd-stdout-interface 0.1.0",
  "nametbd-x86-stdout 0.1.0",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For the freestanding kernel:
 
 ```
 rustup target add wasm32-wasi
+rustup target add wasm32-wasi
 
 # From the root directory of this repository (where the `x86_64-multiboot2.json` file is located):
 RUST_TARGET_PATH=`pwd` cargo +nightly build -Z build-std=core,alloc --target x86_64-multiboot2 --package nametbd-standalone-kernel

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For the freestanding kernel:
 
 ```
 rustup target add wasm32-wasi
-rustup target add wasm32-wasi
+rustup target add wasm32-unknown-unknown
 
 # From the root directory of this repository (where the `x86_64-multiboot2.json` file is located):
 RUST_TARGET_PATH=`pwd` cargo +nightly build -Z build-std=core,alloc --target x86_64-multiboot2 --package nametbd-standalone-kernel

--- a/interfaces/syscalls/src/lib.rs
+++ b/interfaces/syscalls/src/lib.rs
@@ -195,7 +195,7 @@ pub struct MessageResponseFuture<T> {
     marker: PhantomData<T>,
 }
 
-#[cfg(target_arch = "wasm32")] // TODO: bad
+#[cfg(all(feature = "std", target_arch = "wasm32"))] // TODO: bad
 impl<T> Future for MessageResponseFuture<T>
 where
     T: DecodeAll,
@@ -230,7 +230,7 @@ pub struct InterfaceMessageFuture {
     finished: bool,
 }
 
-#[cfg(target_arch = "wasm32")] // TODO: bad
+#[cfg(all(feature = "std", target_arch = "wasm32"))] // TODO: bad
 impl Future for InterfaceMessageFuture {
     type Output = InterfaceMessage;
 

--- a/kernel/cli/build.rs
+++ b/kernel/cli/build.rs
@@ -27,6 +27,7 @@ fn main() {
         .args(&["-C", "link-arg=--export-table"])
         .status()
         .unwrap();
+    assert!(status.success());
 
     // TODO: not a great solution
     for entry in walkdir::WalkDir::new("../../modules/") {

--- a/kernel/gui/build.rs
+++ b/kernel/gui/build.rs
@@ -30,6 +30,7 @@ fn main() {
         .args(&["-C", "link-arg=--export-table"])
         .status()
         .unwrap();
+    assert!(status.success());
 
     // TODO: not a great solution
     for entry in walkdir::WalkDir::new("../../modules/") {

--- a/kernel/standalone/Cargo.toml
+++ b/kernel/standalone/Cargo.toml
@@ -18,6 +18,7 @@ parity-scale-codec = { version = "1.0.5", default-features = false }
 
 [build-dependencies]
 cc = "1.0"
+walkdir = "2.2.9"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 multiboot2 = "0.8.1"

--- a/kernel/standalone/src/main.rs
+++ b/kernel/standalone/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> ! {
     let mut console = unsafe { nametbd_x86_stdout::Console::init() };
 
     let module = nametbd_core::module::Module::from_bytes(
-        &include_bytes!("../../../modules/target/wasm32-unknown-unknown/release/hello.wasm")[..],
+        &include_bytes!("../../../modules/target/wasm32-unknown-unknown/release/hello-world.wasm")[..],
     )
     .unwrap();
 

--- a/kernel/standalone/src/main.rs
+++ b/kernel/standalone/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> ! {
     let mut console = unsafe { nametbd_x86_stdout::Console::init() };
 
     let module = nametbd_core::module::Module::from_bytes(
-        &include_bytes!("../../../modules/target/wasm32-wasi/release/ipfs.wasm")[..],
+        &include_bytes!("../../../modules/target/wasm32-unknown-unknown/release/hello.wasm")[..],
     )
     .unwrap();
 
@@ -112,7 +112,9 @@ fn main() -> ! {
                 // TODO: If we don't support any interface or extrinsic, then `Idle` shouldn't
                 // happen. In a normal situation, this is when we would check the status of the
                 // "externalities", such as the timer.
-                panic!()
+                loop {
+                    unsafe { x86::halt() }
+                }
             }
             nametbd_core::system::SystemRunOutcome::ProgramFinished { pid, outcome } => {
                 console.write(&format!("Program finished {:?} => {:?}\n", pid, outcome));

--- a/kernel/standalone/src/main.rs
+++ b/kernel/standalone/src/main.rs
@@ -96,7 +96,8 @@ fn main() -> ! {
     let mut console = unsafe { nametbd_x86_stdout::Console::init() };
 
     let module = nametbd_core::module::Module::from_bytes(
-        &include_bytes!("../../../modules/target/wasm32-unknown-unknown/release/hello-world.wasm")[..],
+        &include_bytes!("../../../modules/target/wasm32-unknown-unknown/release/hello-world.wasm")
+            [..],
     )
     .unwrap();
 

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -572,6 +572,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hello-world"
+version = "0.1.0"
+dependencies = [
+ "nametbd-stdout-interface 0.1.0",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +847,14 @@ dependencies = [
 
 [[package]]
 name = "nametbd-loader-interface"
+version = "0.1.0"
+dependencies = [
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nametbd-stdout-interface"
 version = "0.1.0"
 dependencies = [
  "nametbd-syscalls-interface 0.1.0",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "hello-world",
     "ipfs",
     "vulkan-triangle",
     "wasm-timer",

--- a/modules/hello-world/Cargo.toml
+++ b/modules/hello-world/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hello-world"
+version = "0.1.0"
+authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+nametbd-stdout-interface = { path = "../../interfaces/stdout" }

--- a/modules/hello-world/src/main.rs
+++ b/modules/hello-world/src/main.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    nametbd_stdout_interface::stdout("hello world!\r".to_string())
+}


### PR DESCRIPTION
![Screenshot from 2019-11-27 22-42-11](https://user-images.githubusercontent.com/1412254/69761287-382d0680-1167-11ea-840c-7dfe4fd862e8.png)

(I'm not sure why there's no new line after "hello world", but that seems like a minor issue)

Rather than trying to start `ipfs` compiled for `wasm32-wasi`, which doesn't work because of #15, we start a basic `hello-world` program compiled to `wasm32-unknown-unknown` and that writes to stdout.

Also, now that we don't use a docker image for libhermit-rs anymore, restores the necessity to have the WASI target installed in order to compile.
