### PR TITLE
Refactor WASI to dispatch to interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nametbd-random-interface"
+version = "0.1.0"
+dependencies = [
+ "nametbd-syscalls-interface 0.1.0",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nametbd-standalone-kernel"
 version = "0.1.0"
 dependencies = [
@@ -688,9 +696,13 @@ name = "nametbd-wasi-hosted"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nametbd-core 0.1.0",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nametbd-random-interface 0.1.0",
+ "nametbd-stdout-interface 0.1.0",
+ "nametbd-time-interface 0.1.0",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.6.2 (git+https://github.com/tomaka/wasmi?branch=no-std)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "kernel/x86-stdout",
     "interfaces/interface",
     "interfaces/loader",
+    "interfaces/random",
     "interfaces/stdout",
     "interfaces/syscalls",
     "interfaces/threads",

--- a/interfaces/random/Cargo.toml
+++ b/interfaces/random/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nametbd-random-interface"
+version = "0.1.0"
+license = "GPL-3.0-or-later"
+authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+nametbd-syscalls-interface = { path = "../syscalls", default-features = false }
+parity-scale-codec = { version = "1.0.5", default-features = false, features = ["derive"] }
+
+[features]
+default = ["std"]
+std = ["nametbd-syscalls-interface/std"]

--- a/interfaces/random/src/ffi.rs
+++ b/interfaces/random/src/ffi.rs
@@ -1,0 +1,39 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::vec::Vec;
+use parity_scale_codec::{Decode, Encode};
+
+// TODO: this has been randomly generated; instead should be a hash or something
+pub const INTERFACE: [u8; 32] = [
+    0xfb, 0x83, 0xa5, 0x46, 0xfd, 0xf1, 0x50, 0x7a, 0xef, 0x8c, 0xb6, 0x8f, 0xa5, 0x44, 0x49, 0x21,
+    0x53, 0xe5, 0x83, 0xda, 0xf0, 0x66, 0xbc, 0x1a, 0xd2, 0x18, 0xfd, 0x00, 0x54, 0x7f, 0xdb, 0x25,
+];
+
+#[derive(Debug, Encode, Decode)]
+pub enum RandomMessage {
+    /// Ask to generate cryptographically-secure list of random numbers of the given length.
+    ///
+    /// The length is a `u16`, so the maximum size is 64kiB and there's no need to handle potential
+    /// errors about the length being too long to fit in memory. Call multiple times to obtain
+    /// more.
+    Generate { len: u16 },
+}
+
+#[derive(Debug, Encode, Decode)]
+pub struct GenerateResponse {
+    /// Random bytes. Must be of the requested length.
+    pub result: Vec<u8>,
+}

--- a/interfaces/random/src/lib.rs
+++ b/interfaces/random/src/lib.rs
@@ -39,9 +39,13 @@ pub async fn generate(len: usize) -> Vec<u8> {
 #[cfg(feature = "std")]
 pub async fn generate_in(out: &mut [u8]) {
     for chunk in out.chunks_mut(usize::from(u16::max_value())) {
-        let msg = ffi::RandomMessage::Generate { len: u16::try_from(chunk.len()).unwrap() };
+        let msg = ffi::RandomMessage::Generate {
+            len: u16::try_from(chunk.len()).unwrap(),
+        };
         let rep: ffi::GenerateResponse =
-            nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).await.unwrap();
+            nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+                .await
+                .unwrap();
         chunk.copy_from_slice(&rep.result);
     }
 }

--- a/interfaces/random/src/lib.rs
+++ b/interfaces/random/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Generating cryptographically-secure random data.
+
+#![deny(intra_doc_link_resolution_failure)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use core::convert::TryFrom;
+
+pub mod ffi;
+
+/// Generate `len` bytes of random data and returns them.
+#[cfg(feature = "std")]
+pub async fn generate(len: usize) -> Vec<u8> {
+    unsafe {
+        let mut out = Vec::with_capacity(len);
+        out.set_len(len);
+        generate_in(&mut out).await;
+        out
+    }
+}
+
+/// Fills `out` with randomly-generated data.
+#[cfg(feature = "std")]
+pub async fn generate_in(out: &mut [u8]) {
+    for chunk in out.chunks_mut(usize::from(u16::max_value())) {
+        let msg = ffi::RandomMessage::Generate { len: u16::try_from(chunk.len()).unwrap() };
+        let rep: ffi::GenerateResponse =
+            nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).await.unwrap();
+        chunk.copy_from_slice(&rep.result);
+    }
+}

--- a/kernel/hosted-wasi/Cargo.toml
+++ b/kernel/hosted-wasi/Cargo.toml
@@ -8,9 +8,13 @@ publish = false
 
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
+hashbrown = { version = "0.6.0", default-features = false }
 lazy_static = "1.4"
 nametbd-core = { path = "../../core" }
-rand = "0.7"
+nametbd-random-interface = { path = "../../interfaces/random" }
+nametbd-stdout-interface = { path = "../../interfaces/stdout" }
+nametbd-time-interface = { path = "../../interfaces/time" }
+parity-scale-codec = { version = "1.1.0", default-features = false }
 
 # TODO: remove
 wasmi = { git = "https://github.com/tomaka/wasmi", branch = "no-std", default-features = false, features = ["core"] }

--- a/kernel/hosted-wasi/src/lib.rs
+++ b/kernel/hosted-wasi/src/lib.rs
@@ -13,13 +13,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{string::String, string::ToString as _, vec, vec::Vec};
 use byteorder::{ByteOrder as _, LittleEndian};
+use core::convert::{TryFrom as _};
+use hashbrown::HashMap;
 use nametbd_core::scheduler::{Pid, ThreadId};
 use nametbd_core::system::{System, SystemBuilder};
-use std::{
-    io::Write as _,
-    time::{Instant, SystemTime},
-};
+use parity_scale_codec::{Encode as _, DecodeAll};
 
 // TODO: lots of unwraps as `as` conversions in this module
 
@@ -42,6 +46,9 @@ enum WasiExtrinsicInner {
     RandomGet,
     SchedYield,
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct WasmMessageId(u64);
 
 /// Adds to the `SystemBuilder` the extrinsics required by WASI.
 pub fn register_extrinsics<T: From<WasiExtrinsic> + Clone>(
@@ -123,108 +130,210 @@ pub fn register_extrinsics<T: From<WasiExtrinsic> + Clone>(
         )
 }
 
-pub fn handle_wasi(
-    system: &mut System<impl Clone>,
-    extrinsic: WasiExtrinsic,
-    pid: Pid,
-    thread_id: ThreadId,
-    params: Vec<wasmi::RuntimeValue>,
-) {
-    const ENV_VARS: &[u8] = b"RUST_BACKTRACE=1\0";
+pub struct WasiStateMachine {
+    /// All the interface messages that we emited and for which we're expecting a response.
+    pending_messages: HashMap<WasmMessageId, CallInfo>,
+}
 
-    match extrinsic.0 {
-        WasiExtrinsicInner::ArgsGet => unimplemented!(),
-        WasiExtrinsicInner::ArgsSizesGet => {
-            assert_eq!(params.len(), 2);
-            let num_ptr = params[0].try_into::<i32>().unwrap() as u32;
-            let buf_size_ptr = params[1].try_into::<i32>().unwrap() as u32;
-            system.write_memory(pid, num_ptr, &[0, 0, 0, 0]).unwrap();
-            system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
-        }
-        WasiExtrinsicInner::ClockTimeGet => {
-            assert_eq!(params.len(), 3);
-            // Note: precision is ignored
-            let clock_ty = params[0].try_into::<i32>().unwrap();
-            let dur = match clock_ty {
-                0 => {
-                    // CLOCK_REALTIME
-                    // Note: `elapsed()` errors if `now() > &self`, which should never happen here.
-                    SystemTime::UNIX_EPOCH.elapsed().unwrap()
-                }
-                1 => {
-                    // CLOCK_MONOTONIC
-                    lazy_static::lazy_static! {
-                        static ref CLOCK_START: Instant = Instant::now();
-                    }
-                    CLOCK_START.elapsed()
-                }
-                2 => {
-                    // CLOCK_PROCESS_CPUTIME_ID
-                    unimplemented!()
-                }
-                3 => {
-                    // CLOCK_THREAD_CPUTIME_ID
-                    unimplemented!()
-                }
-                _ => panic!(),
-            };
-            let write_back = dur
-                .as_secs()
-                .saturating_mul(1_000_000_000)
-                .saturating_add(u64::from(dur.subsec_nanos()));
-            let mut buf = [0; 8];
-            LittleEndian::write_u64(&mut buf, write_back);
-            let buf_ptr = params[2].try_into::<i32>().unwrap() as u32;
-            system.write_memory(pid, buf_ptr, &buf).unwrap();
-            system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
-        }
-        WasiExtrinsicInner::EnvironGet => {
-            assert_eq!(params.len(), 2);
-            let ptrs_ptr = params[0].try_into::<i32>().unwrap() as u32;
-            let buf_ptr = params[1].try_into::<i32>().unwrap() as u32;
-            let mut buf = [0; 4];
-            LittleEndian::write_u32(&mut buf, buf_ptr);
-            system.write_memory(pid, ptrs_ptr, &buf).unwrap();
-            system.write_memory(pid, buf_ptr, ENV_VARS).unwrap();
-            system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
-        }
-        WasiExtrinsicInner::EnvironSizesGet => {
-            assert_eq!(params.len(), 2);
-            let num_ptr = params[0].try_into::<i32>().unwrap() as u32;
-            let buf_size_ptr = params[1].try_into::<i32>().unwrap() as u32;
-            let mut buf = [0; 4];
-            LittleEndian::write_u32(&mut buf, 1);
-            system.write_memory(pid, num_ptr, &buf).unwrap();
-            LittleEndian::write_u32(&mut buf, ENV_VARS.len() as u32);
-            system.write_memory(pid, buf_size_ptr, &buf).unwrap();
-            system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
-        }
-        WasiExtrinsicInner::FdPrestatGet => {
-            assert_eq!(params.len(), 2);
-            let fd = params[0].try_into::<i32>().unwrap() as usize;
-            let ptr = params[1].try_into::<i32>().unwrap() as u32;
-            //system.write_memory(pid, ptr, &[0]).unwrap();
-            // TODO: incorrect
-            system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(8)));
-        }
-        WasiExtrinsicInner::FdPrestatDirName => unimplemented!(),
-        WasiExtrinsicInner::FdFdstatGet => unimplemented!(),
-        WasiExtrinsicInner::FdWrite => fd_write(system, pid, thread_id, params),
-        WasiExtrinsicInner::ProcExit => unimplemented!(),
-        WasiExtrinsicInner::RandomGet => {
-            assert_eq!(params.len(), 2);
-            let buf = params[0].try_into::<i32>().unwrap() as u32;
-            let len = params[1].try_into::<i32>().unwrap() as u32;
-            let mut randomness = Vec::<u8>::new();
-            for _ in 0..len {
-                randomness.push(rand::random());
+enum CallInfo {
+    Time(TimeCallInfo),
+    Random(RandomCallInfo),
+}
+
+struct TimeCallInfo {
+    pid: Pid,
+    tid: ThreadId,
+    /// Address of an 8 bytes buffer within the memory of `pid` where to write the result in
+    /// little endian.
+    out_ptr: u32,
+}
+
+struct RandomCallInfo {
+    pid: Pid,
+    tid: ThreadId,
+    /// Pointer to the memory of `pid` of a buffer of length `remaining_len`.
+    out_ptr: u32,
+    /// Length of the buffer in `out_ptr` that must be filled with random data.
+    remaining_len: u32,
+}
+
+pub enum HandleOut {
+    Ok,
+    EmitMessage {
+        id: Option<WasmMessageId>,
+        interface: [u8; 32],
+        message: Vec<u8>,
+    }
+}
+
+impl WasiStateMachine {
+    fn alloc_message_id(&mut self) -> WasmMessageId {
+        WasmMessageId(0)        // FIXME:
+    }
+
+    /// Call this when a process performs a WASI extrinsic call.
+    pub fn handle_extrinsic_call(
+        &mut self,  // TODO: replace with `&self`
+        system: &mut System<impl Clone>,
+        extrinsic: WasiExtrinsic,
+        pid: Pid,
+        thread_id: ThreadId,
+        params: Vec<wasmi::RuntimeValue>,
+    ) -> HandleOut {
+        const ENV_VARS: &[u8] = b"RUST_BACKTRACE=1\0";
+
+        match extrinsic.0 {
+            WasiExtrinsicInner::ArgsGet => unimplemented!(),
+            WasiExtrinsicInner::ArgsSizesGet => {
+                assert_eq!(params.len(), 2);
+                let num_ptr = params[0].try_into::<i32>().unwrap() as u32;
+                let buf_size_ptr = params[1].try_into::<i32>().unwrap() as u32;
+                system.write_memory(pid, num_ptr, &[0, 0, 0, 0]).unwrap();
+                system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
+                HandleOut::Ok
             }
-            system.write_memory(pid, buf, &randomness).unwrap();
-            system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
+            WasiExtrinsicInner::ClockTimeGet => {
+                assert_eq!(params.len(), 3);
+                // Note: precision is ignored
+                let clock_ty = params[0].try_into::<i32>().unwrap();
+                let out_ptr = params[2].try_into::<i32>().unwrap() as u32;
+                let message = match clock_ty {
+                    0 => {
+                        // CLOCK_REALTIME
+                        nametbd_time_interface::ffi::TimeMessage::GetSystem
+                    }
+                    1 => {
+                        // CLOCK_MONOTONIC
+                        nametbd_time_interface::ffi::TimeMessage::GetMonotonic
+                    }
+                    2 => {
+                        // CLOCK_PROCESS_CPUTIME_ID
+                        unimplemented!()
+                    }
+                    3 => {
+                        // CLOCK_THREAD_CPUTIME_ID
+                        unimplemented!()
+                    }
+                    _ => panic!(),
+                };
+                let msg_id = self.alloc_message_id();
+                let _prev_val = self.pending_messages.insert(msg_id, CallInfo::Time(TimeCallInfo {
+                    pid,
+                    tid: thread_id,
+                    out_ptr,
+                }));
+                debug_assert!(_prev_val.is_none());
+                HandleOut::EmitMessage {
+                    id: Some(msg_id),
+                    interface: nametbd_time_interface::ffi::INTERFACE,
+                    message: message.encode(),
+                }
+            }
+            WasiExtrinsicInner::EnvironGet => {
+                assert_eq!(params.len(), 2);
+                let ptrs_ptr = params[0].try_into::<i32>().unwrap() as u32;
+                let buf_ptr = params[1].try_into::<i32>().unwrap() as u32;
+                let mut buf = [0; 4];
+                LittleEndian::write_u32(&mut buf, buf_ptr);
+                system.write_memory(pid, ptrs_ptr, &buf).unwrap();
+                system.write_memory(pid, buf_ptr, ENV_VARS).unwrap();
+                system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
+                HandleOut::Ok
+            }
+            WasiExtrinsicInner::EnvironSizesGet => {
+                assert_eq!(params.len(), 2);
+                let num_ptr = params[0].try_into::<i32>().unwrap() as u32;
+                let buf_size_ptr = params[1].try_into::<i32>().unwrap() as u32;
+                let mut buf = [0; 4];
+                LittleEndian::write_u32(&mut buf, 1);
+                system.write_memory(pid, num_ptr, &buf).unwrap();
+                LittleEndian::write_u32(&mut buf, ENV_VARS.len() as u32);
+                system.write_memory(pid, buf_size_ptr, &buf).unwrap();
+                system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
+                HandleOut::Ok
+            }
+            WasiExtrinsicInner::FdPrestatGet => {
+                assert_eq!(params.len(), 2);
+                let fd = params[0].try_into::<i32>().unwrap() as usize;
+                let ptr = params[1].try_into::<i32>().unwrap() as u32;
+                //system.write_memory(pid, ptr, &[0]).unwrap();
+                // TODO: incorrect
+                system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(8)));
+                HandleOut::Ok
+            }
+            WasiExtrinsicInner::FdPrestatDirName => unimplemented!(),
+            WasiExtrinsicInner::FdFdstatGet => unimplemented!(),
+            WasiExtrinsicInner::FdWrite => fd_write(system, pid, thread_id, params),
+            WasiExtrinsicInner::ProcExit => unimplemented!(),
+            WasiExtrinsicInner::RandomGet => {
+                assert_eq!(params.len(), 2);
+                let buf = params[0].try_into::<i32>().unwrap() as u32;
+                let len = params[1].try_into::<i32>().unwrap() as u32;
+
+                let msg_id = self.alloc_message_id();
+                let _prev_val = self.pending_messages.insert(msg_id, CallInfo::Random(RandomCallInfo {
+                    pid,
+                    tid: thread_id,
+                    out_ptr: buf,
+                    remaining_len: len,
+                }));
+                debug_assert!(_prev_val.is_none());
+                
+                let len_to_request = u16::try_from(len).unwrap_or(u16::max_value());
+                let message = nametbd_random_interface::ffi::RandomMessage::Generate { len: len_to_request };
+                HandleOut::EmitMessage {
+                    id: Some(msg_id),
+                    interface: nametbd_random_interface::ffi::INTERFACE,
+                    message: message.encode(),
+                }
+            }
+            WasiExtrinsicInner::SchedYield => {
+                // TODO: guarantee the yield
+                system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
+                HandleOut::Ok
+            }
         }
-        WasiExtrinsicInner::SchedYield => {
-            // TODO: guarantee the yield
-            system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
+    }
+
+    // TODO: make `&self`
+    pub fn message_response(&mut self, system: &mut System<impl Clone>, msg_id: WasmMessageId, response: Vec<u8>)
+    -> HandleOut {
+        match self.pending_messages.remove(&msg_id) {
+            Some(CallInfo::Time(info)) => {
+                let value: u128 = DecodeAll::decode_all(&response).unwrap();
+                let to_write = u64::try_from(value).unwrap_or(u64::max_value());        // TODO: meh; return an error instead?
+                let mut buf = [0; 8];
+                LittleEndian::write_u64(&mut buf, to_write);
+                system.write_memory(info.pid, info.out_ptr, &buf).unwrap();
+                system.resolve_extrinsic_call(info.tid, Some(wasmi::RuntimeValue::I32(0)));
+                HandleOut::Ok
+            },
+            Some(CallInfo::Random(mut info)) => {
+                let value: nametbd_random_interface::ffi::GenerateResponse = DecodeAll::decode_all(&response).unwrap();
+                assert!(u32::try_from(value.result.len()).unwrap_or(u32::max_value()) <= info.remaining_len);
+                system.write_memory(info.pid, info.out_ptr, &value.result).unwrap();
+                info.remaining_len -= value.result.len() as u32;        // TODO: as :-/
+
+                if info.remaining_len == 0 {
+                    system.resolve_extrinsic_call(info.tid, Some(wasmi::RuntimeValue::I32(0)));
+                    HandleOut::Ok
+
+                } else {
+                    let msg_id = self.alloc_message_id();
+                    let len_to_request = u16::try_from(info.remaining_len).unwrap_or(u16::max_value());
+
+                    let _prev_val = self.pending_messages.insert(msg_id, CallInfo::Random(info));
+                    debug_assert!(_prev_val.is_none());
+
+                    let message = nametbd_random_interface::ffi::RandomMessage::Generate { len: len_to_request };
+                    HandleOut::EmitMessage {
+                        id: Some(msg_id),
+                        interface: nametbd_random_interface::ffi::INTERFACE,
+                        message: message.encode(),
+                    }
+                }
+            },
+            None => panic!()        // TODO:
         }
     }
 }
@@ -234,7 +343,7 @@ fn fd_write(
     pid: nametbd_core::scheduler::Pid,
     thread_id: nametbd_core::scheduler::ThreadId,
     params: Vec<wasmi::RuntimeValue>,
-) {
+) -> HandleOut {
     assert_eq!(params.len(), 4); // TODO: what to do when it's not the case?
 
     //assert!(params[0] == wasmi::RuntimeValue::I32(1) || params[0] == wasmi::RuntimeValue::I32(2));      // either stdout or stderr
@@ -252,14 +361,14 @@ fn fd_write(
     };
 
     let mut total_written = 0;
+    let mut to_write = Vec::new();
 
     for ptr_and_len in list_to_write.windows(2) {
         let ptr = ptr_and_len[0] as u32;
         let len = ptr_and_len[1] as u32;
 
-        let to_write = system.read_memory(pid, ptr, len).unwrap();
-        std::io::stdout().write_all(&to_write).unwrap();
-        total_written += to_write.len();
+        to_write.extend(system.read_memory(pid, ptr, len).unwrap());
+        total_written += len as usize;
     }
 
     // Write to the fourth parameter the number of bytes written to the file descriptor.
@@ -271,4 +380,9 @@ fn fd_write(
     }
 
     system.resolve_extrinsic_call(thread_id, Some(wasmi::RuntimeValue::I32(0)));
+    HandleOut::EmitMessage {
+        id: None,
+        interface: nametbd_stdout_interface::ffi::INTERFACE,
+        message: nametbd_stdout_interface::ffi::StdoutMessage::Message(String::from_utf8_lossy(&to_write).to_string()).encode(),       // TODO:  lossy?
+    }
 }


### PR DESCRIPTION
Close #15 

Instead of having the WASI handler directly respond to function calls, it will instead emit messages (when necessary, i.e. for time, randomness, and stdout) and answer the extrinsic call when the message response comes back.