### PR TITLE
Make freestanding kernel work on ARM

### DIFF
--- a/arm-freestanding.json
+++ b/arm-freestanding.json
@@ -1,0 +1,31 @@
+{
+    "abi-blacklist": [
+        "stdcall",
+        "fastcall",
+        "vectorcall",
+        "thiscall",
+        "win64",
+        "sysv64"
+    ],
+    "arch": "arm",
+    "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
+    "emit-debug-gdb-scripts": false,
+    "env": "",
+    "executables": true,
+    "is-builtin": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
+    "lld-flavor": "link",
+    "llvm-target": "armv7r-unknown-none-eabi",
+    "max-atomic-width": 32,
+    "os": "none",
+    "panic-strategy": "abort",
+    "pre-link-args": {
+        "ld": ["--script", "arm-freestanding.ld"]
+    },
+    "relocation-model": "static",
+    "target-c-int-width": "32",
+    "target-endian": "little",
+    "target-pointer-width": "32",
+    "vendor": ""
+}

--- a/arm-freestanding.ld
+++ b/arm-freestanding.ld
@@ -1,0 +1,41 @@
+ENTRY(_start)
+
+SECTIONS {
+    . = 0x0;
+    .startup : AT(ADDR(.startup)) {
+        /* Jump to the address of `_start` */
+        /* Note that the value is an offset, therefore this only works because our address here is 0x0 */
+        /* TODO: this always fails, no clue why: ASSERT(((_start >> 2) - 2) == (((_start >> 2) - 2) & 0x1FFFFFF), "_start too far away") */
+        LONG(0xea000000 | (((_start >> 2) - 2) & 0x1FFFFFF))
+
+        /* Interrupt descriptor table */
+        LONG(0xeafffffe)
+        LONG(0xeafffffe)
+        LONG(0xeafffffe)
+        LONG(0xeafffffe)
+        LONG(0xeafffffe)
+        LONG(0xeafffffe)
+        LONG(0xeafffffe)
+    }
+
+    . = 0x10000;
+    .text : AT(ADDR(.text)) {
+        *(.text*)
+        *(.rodata*)
+    }
+
+    /* Garbage that the compiler seems to introduce for stack unwinding purposes */
+    .ARM.exidx : AT(ADDR(.ARM.exidx)) {
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+    }
+
+    .data : AT(ADDR(.data)) {
+        *(.data*)
+    }
+
+    .bss : AT(ADDR(.bss)) {
+        *(.bss*)
+        *(COMMON*)
+    }
+}

--- a/core/src/id_pool.rs
+++ b/core/src/id_pool.rs
@@ -15,7 +15,7 @@
 
 use core::{
     fmt,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
 };
 // TODO: use crossbeam::queue::SegQueue;
 use rand::distributions::{Distribution as _, Uniform};
@@ -32,7 +32,7 @@ pub struct IdPool {
     // TODO: /// Queue of RNG objects. Since generating a value requires an exclusive reference to the
     // TODO: /// RNG object, we hold a queue of objects.
     // TODO: rngs_queue: SegQueue<ChaCha20Rng>,
-    next_val: AtomicU64,
+    next_val: AtomicU32,
     /// Distribution of IDs.
     distribution: Uniform<u64>,
 }
@@ -41,7 +41,7 @@ impl IdPool {
     /// Initializes a new pool.
     pub fn new() -> Self {
         IdPool {
-            next_val: AtomicU64::new(0),
+            next_val: AtomicU32::new(0),
             // TODO: rngs_queue: SegQueue::new(),
             distribution: Uniform::from(0..=u64::max_value()),
         }
@@ -50,7 +50,7 @@ impl IdPool {
     /// Assigns a new PID from this pool.
     pub fn assign<T: From<u64>>(&self) -> T {
         let id = self.next_val.fetch_add(1, Ordering::Relaxed);
-        T::from(id)
+        T::from(id.into())
     }
 }
 

--- a/kernel/standalone/build.rs
+++ b/kernel/standalone/build.rs
@@ -23,6 +23,13 @@ fn main() {
             .file("src/arch/x86_64/boot.S")
             .include("src")
             .compile("libboot.a");
+
+    } else if target.starts_with("arm") || target.starts_with("aarch64") {
+        /*cc::Build::new()
+            .file("src/arch/arm/boot.S")
+            .include("src")
+            .compile("libboot.a");*/
+
     } else {
         panic!("Unsupported target: {:?}", target)
     }

--- a/kernel/standalone/src/arch.rs
+++ b/kernel/standalone/src/arch.rs
@@ -13,7 +13,44 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+mod arm;
 mod x86_64;
 
+#[cfg(target_arch = "aarch64")]
+pub use arm::*;
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;
+
+// TODO: figure out how to remove these
+/*#[no_mangle]
+pub extern "C" fn fmod(a: f64, b: f64) -> f64 {
+    libm::fmod(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fmodf(a: f32, b: f32) -> f32 {
+    libm::fmodf(a, b)
+}*/
+#[no_mangle]
+pub extern "C" fn fmin(a: f64, b: f64) -> f64 {
+    libm::fmin(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fminf(a: f32, b: f32) -> f32 {
+    libm::fminf(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fmax(a: f64, b: f64) -> f64 {
+    libm::fmax(a, b)
+}
+#[no_mangle]
+pub extern "C" fn fmaxf(a: f32, b: f32) -> f32 {
+    libm::fmaxf(a, b)
+}
+#[no_mangle]
+pub extern "C" fn __truncdfsf2(a: f64) -> f32 {
+    libm::trunc(a) as f32 // TODO: correct?
+}
+#[no_mangle]
+pub extern "C" fn __aeabi_d2f(a: f64) -> f32 {
+    libm::trunc(a) as f32 // TODO: correct?
+}

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -1,0 +1,60 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#[no_mangle]
+extern "C" fn dummy_fn() {
+    unsafe {
+        asm!(r#"
+.comm stack, 0x40000, 8
+
+_start:
+    .globl _start
+    ldr sp, =stack+0x40000
+    b after_boot
+
+"#);
+    }
+}
+
+#[no_mangle]
+extern "C" fn after_boot() -> ! {
+    write_serial(b"hello world\n".iter().cloned());
+    unsafe {
+        asm!("b .");
+    }
+    unsafe { core::intrinsics::unreachable() }
+    //crate::main()
+}
+
+fn write_uart(data: impl Iterator<Item = u8>) {
+    unsafe {
+        let base_ptr = 0x101f1000 as *mut u32;
+        for byte in data {
+            base_ptr.write_volatile(u32::from(byte));
+        }
+    }
+}
+
+fn write_serial(data: impl Iterator<Item = u8>) {
+    unsafe {
+        let base_ptr = 0x16000000 as *mut u8;
+        let register = 0x16000018 as *mut u8;
+
+        for byte in data {
+            while register.read_volatile() & (1 << 5) != 0 {}
+            base_ptr.write_volatile(byte);
+        }
+    }
+}

--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -18,36 +18,6 @@
 #[link(name = "boot")]
 extern "C" {}
 
-// TODO: figure out how to remove these
-#[no_mangle]
-pub extern "C" fn fmod(a: f64, b: f64) -> f64 {
-    libm::fmod(a, b)
-}
-#[no_mangle]
-pub extern "C" fn fmodf(a: f32, b: f32) -> f32 {
-    libm::fmodf(a, b)
-}
-#[no_mangle]
-pub extern "C" fn fmin(a: f64, b: f64) -> f64 {
-    libm::fmin(a, b)
-}
-#[no_mangle]
-pub extern "C" fn fminf(a: f32, b: f32) -> f32 {
-    libm::fminf(a, b)
-}
-#[no_mangle]
-pub extern "C" fn fmax(a: f64, b: f64) -> f64 {
-    libm::fmax(a, b)
-}
-#[no_mangle]
-pub extern "C" fn fmaxf(a: f32, b: f32) -> f32 {
-    libm::fmaxf(a, b)
-}
-#[no_mangle]
-pub extern "C" fn __truncdfsf2(a: f64) -> f32 {
-    libm::trunc(a) as f32 // TODO: correct?
-}
-
 /// Called by `boot.S` after basic set up has been performed.
 ///
 /// When this function is called, a stack has been set up and as much memory space as possible has

--- a/kernel/standalone/src/main.rs
+++ b/kernel/standalone/src/main.rs
@@ -17,6 +17,8 @@
 
 #![no_std]
 #![no_main]
+#![feature(asm)]
+#![feature(core_intrinsics)]
 #![feature(panic_info_message)] // TODO: https://github.com/rust-lang/rust/issues/66745
 #![feature(alloc_error_handler)] // TODO: https://github.com/rust-lang/rust/issues/66741
 
@@ -77,7 +79,7 @@ fn panic(panic_info: &core::panic::PanicInfo) -> ! {
     }
 
     loop {
-        unsafe { x86::halt() }
+        //unsafe { x86::halt() }
     }
 }
 
@@ -114,7 +116,7 @@ fn main() -> ! {
                 // happen. In a normal situation, this is when we would check the status of the
                 // "externalities", such as the timer.
                 loop {
-                    unsafe { x86::halt() }
+                    //unsafe { x86::halt() }
                 }
             }
             nametbd_core::system::SystemRunOutcome::ProgramFinished { pid, outcome } => {


### PR DESCRIPTION
Very work-in-progress.

Compilation is done the same way as for x86:

> RUST_TARGET_PATH=`pwd` cargo +nightly b -Z build-std=core,alloc --package nametbd-standalone-kernel --release --target arm-freestanding

Theoretically, this is supposed to print `"hello world"` on the serial port, which QEMU is supposed to pick up when you pass `-serial stdio`. It doesn't seem to work, but if I use QEMU's debugger everything seems to run fine. I'm suspecting that the kernel runs fine, and it's just this serial port thing not working.

Will merge when the state is the same as for x86_64, i.e. basic stdout working and the WASM VM running.
