### PR TITLE
Make WASI work for the standalone kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,6 @@ jobs:
         toolchain: nightly
         target: wasm32-wasi
         override: true
-    - name: Install wasm32-unknown-unknown
-      run: rustup target add wasm32-unknown-unknown
     - name: Install rust-src
       run: rustup component add rust-src
     - name: Build core for no_std platform

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "multiboot2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nametbd-core 0.1.0",
  "nametbd-stdout-interface 0.1.0",
+ "nametbd-wasi-hosted 0.1.0",
  "nametbd-x86-stdout 0.1.0",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -697,7 +698,6 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nametbd-core 0.1.0",
  "nametbd-random-interface 0.1.0",
  "nametbd-stdout-interface 0.1.0",

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ For the freestanding kernel:
 
 ```
 rustup target add wasm32-wasi
-rustup target add wasm32-unknown-unknown
 
 # From the root directory of this repository (where the `x86_64-multiboot2.json` file is located):
 RUST_TARGET_PATH=`pwd` cargo +nightly build -Z build-std=core,alloc --target x86_64-multiboot2 --package nametbd-standalone-kernel

--- a/interfaces/time/Cargo.toml
+++ b/interfaces/time/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-nametbd-syscalls-interface = { path = "../syscalls" }
-parity-scale-codec = { version = "1.0.5", features = ["derive"] }
+nametbd-syscalls-interface = { path = "../syscalls", default-features = false }
+parity-scale-codec = { version = "1.0.5", default-features = false, features = ["derive"] }
 pin-project = "0.4.6"
+
+[features]
+default = ["std"]
+std = ["nametbd-syscalls-interface/std"]

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -16,17 +16,23 @@
 //! Time.
 
 #![deny(intra_doc_link_resolution_failure)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-use std::time::Duration;
+use core::time::Duration;
 
+#[cfg(feature = "std")]
 pub use self::delay::Delay;
+#[cfg(feature = "std")]
 pub use self::instant::Instant;
 
+#[cfg(feature = "std")]
 mod delay;
 pub mod ffi;
+#[cfg(feature = "std")]
 mod instant;
 
 /// Returns the number of nanoseconds since an arbitrary point in time in the past.
+#[cfg(feature = "std")]
 pub async fn monotonic_clock() -> u128 {
     let msg = ffi::TimeMessage::GetMonotonic;
     nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
@@ -35,6 +41,7 @@ pub async fn monotonic_clock() -> u128 {
 }
 
 /// Returns the number of nanoseconds since the Epoch (January 1st, 1970 at midnight UTC).
+#[cfg(feature = "std")]
 pub async fn system_clock() -> u128 {
     let msg = ffi::TimeMessage::GetSystem;
     nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
@@ -43,6 +50,7 @@ pub async fn system_clock() -> u128 {
 }
 
 /// Returns a `Future` that yields when the monotonic clock reaches this value.
+#[cfg(feature = "std")]
 pub async fn monotonic_wait_until(until: u128) {
     let msg = ffi::TimeMessage::WaitMonotonic(until);
     nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
@@ -51,6 +59,7 @@ pub async fn monotonic_wait_until(until: u128) {
 }
 
 /// Returns a `Future` that outputs after `duration` has elapsed.
+#[cfg(feature = "std")]
 pub async fn monotonic_wait(duration: Duration) {
     let dur_nanos = u128::from(duration.as_secs())
         .saturating_mul(1_000_000_000)

--- a/kernel/hosted-wasi/Cargo.toml
+++ b/kernel/hosted-wasi/Cargo.toml
@@ -9,11 +9,10 @@ publish = false
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
 hashbrown = { version = "0.6.0", default-features = false }
-lazy_static = "1.4"
-nametbd-core = { path = "../../core" }
-nametbd-random-interface = { path = "../../interfaces/random" }
-nametbd-stdout-interface = { path = "../../interfaces/stdout" }
-nametbd-time-interface = { path = "../../interfaces/time" }
+nametbd-core = { path = "../../core", default-features = false }
+nametbd-random-interface = { path = "../../interfaces/random", default-features = false }
+nametbd-stdout-interface = { path = "../../interfaces/stdout", default-features = false }
+nametbd-time-interface = { path = "../../interfaces/time", default-features = false }
 parity-scale-codec = { version = "1.1.0", default-features = false }
 
 # TODO: remove

--- a/kernel/standalone/Cargo.toml
+++ b/kernel/standalone/Cargo.toml
@@ -13,6 +13,7 @@ libm = "0.2.1"
 linked_list_allocator = "0.6.4"
 nametbd-core = { path = "../../core" }
 nametbd-stdout-interface = { path = "../../interfaces/stdout" }
+nametbd-wasi-hosted = { path = "../hosted-wasi" }
 nametbd-x86-stdout = { path = "../x86-stdout" }
 parity-scale-codec = { version = "1.0.5", default-features = false }
 

--- a/kernel/standalone/build.rs
+++ b/kernel/standalone/build.rs
@@ -31,7 +31,7 @@ fn main() {
     let status = Command::new("cargo")
         .arg("rustc")
         .arg("--release")
-        .args(&["--target", "wasm32-unknown-unknown"])
+        .args(&["--target", "wasm32-wasi"])
         .args(&["--package", "hello-world"])
         .args(&["--bin", "hello-world"])
         .args(&["--manifest-path", "../../modules/hello-world/Cargo.toml"])

--- a/kernel/standalone/src/main.rs
+++ b/kernel/standalone/src/main.rs
@@ -96,16 +96,18 @@ fn main() -> ! {
     let mut console = unsafe { nametbd_x86_stdout::Console::init() };
 
     let module = nametbd_core::module::Module::from_bytes(
-        &include_bytes!("../../../modules/target/wasm32-unknown-unknown/release/hello-world.wasm")
-            [..],
+        &include_bytes!("../../../modules/target/wasm32-wasi/release/hello-world.wasm")[..],
     )
     .unwrap();
 
-    let mut system = nametbd_core::system::SystemBuilder::<()>::new() // TODO: `!` instead
-        .with_interface_handler(nametbd_stdout_interface::ffi::INTERFACE)
-        .with_startup_process(module)
-        .with_main_program([0; 32]) // TODO: just a test
-        .build();
+    let mut system =
+        nametbd_wasi_hosted::register_extrinsics(nametbd_core::system::SystemBuilder::new())
+            .with_interface_handler(nametbd_stdout_interface::ffi::INTERFACE)
+            .with_startup_process(module)
+            .with_main_program([0; 32]) // TODO: just a test
+            .build();
+
+    let mut wasi = nametbd_wasi_hosted::WasiStateMachine::new();
 
     loop {
         match system.run() {
@@ -115,6 +117,31 @@ fn main() -> ! {
                 // "externalities", such as the timer.
                 loop {
                     unsafe { x86::halt() }
+                }
+            }
+            nametbd_core::system::SystemRunOutcome::ThreadWaitExtrinsic {
+                pid,
+                thread_id,
+                extrinsic,
+                params,
+            } => {
+                let out =
+                    wasi.handle_extrinsic_call(&mut system, extrinsic, pid, thread_id, params);
+                if let nametbd_wasi_hosted::HandleOut::EmitMessage {
+                    id,
+                    interface,
+                    message,
+                } = out
+                {
+                    if interface == nametbd_stdout_interface::ffi::INTERFACE {
+                        let msg =
+                            nametbd_stdout_interface::ffi::StdoutMessage::decode_all(&message);
+                        let nametbd_stdout_interface::ffi::StdoutMessage::Message(msg) =
+                            msg.unwrap();
+                        console.write(&msg);
+                    } else {
+                        panic!()
+                    }
                 }
             }
             nametbd_core::system::SystemRunOutcome::ProgramFinished { pid, outcome } => {


### PR DESCRIPTION
Follow-up of #92 

Now that WASI is no-std-friendly, makes the standalone kernel compile "hello-world" for WASI rather than wasm-unknown.
