### PR TITLE
Clean up syscalls-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/interfaces/interface/src/lib.rs
+++ b/interfaces/interface/src/lib.rs
@@ -36,10 +36,11 @@ pub mod ffi;
 pub async fn register_interface(hash: [u8; 32]) -> Result<(), InterfaceRegisterError> {
     let msg = ffi::InterfaceMessage::Register(hash);
     // TODO: we unwrap cause there's always something that handles interface registration; is that correct?
-    let rep: ffi::InterfaceRegisterResponse =
+    let rep: ffi::InterfaceRegisterResponse = unsafe {
         nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
             .await
-            .unwrap();
+            .unwrap()
+    };
     rep.result
 }
 

--- a/interfaces/loader/src/lib.rs
+++ b/interfaces/loader/src/lib.rs
@@ -32,10 +32,14 @@ pub mod ffi;
 #[cfg(target_arch = "wasm32")] // TODO: bad
 #[cfg(feature = "std")]
 pub async fn load(hash: [u8; 32]) -> Result<Vec<u8>, ()> {
-    let msg = ffi::LoaderMessage::Load(hash);
-    let rep: ffi::LoadResponse =
-        nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).await?;
-    rep.result
+    unsafe {
+        let msg = ffi::LoaderMessage::Load(hash);
+        let rep: ffi::LoadResponse =
+            nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+                .await
+                .map_err(|_| ())?;
+        rep.result
+    }
 }
 
 /// Tries to load a WASM module based on its hash.

--- a/interfaces/random/Cargo.toml
+++ b/interfaces/random/Cargo.toml
@@ -11,4 +11,4 @@ parity-scale-codec = { version = "1.0.5", default-features = false, features = [
 
 [features]
 default = ["std"]
-std = ["nametbd-syscalls-interface/std"]
+std = []

--- a/interfaces/random/src/lib.rs
+++ b/interfaces/random/src/lib.rs
@@ -42,10 +42,11 @@ pub async fn generate_in(out: &mut [u8]) {
         let msg = ffi::RandomMessage::Generate {
             len: u16::try_from(chunk.len()).unwrap(),
         };
-        let rep: ffi::GenerateResponse =
+        let rep: ffi::GenerateResponse = unsafe {
             nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
                 .await
-                .unwrap();
+                .unwrap()
+        };
         chunk.copy_from_slice(&rep.result);
     }
 }

--- a/interfaces/stdout/src/lib.rs
+++ b/interfaces/stdout/src/lib.rs
@@ -31,6 +31,8 @@ pub mod ffi;
 /// In order to follow the Unix world, the character `\n` (LF, 0xA) means "new line". The
 /// character `\r` (CR, 0xD) is ignored.
 pub fn stdout(msg: String) {
-    let msg = ffi::StdoutMessage::Message(msg);
-    nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &msg, false).unwrap();
+    unsafe {
+        let msg = ffi::StdoutMessage::Message(msg);
+        nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &msg, false).unwrap();
+    }
 }

--- a/interfaces/syscalls/Cargo.toml
+++ b/interfaces/syscalls/Cargo.toml
@@ -10,9 +10,5 @@ futures = { version = "0.3.1", default-features = false, features = ["alloc"] }
 hashbrown = { version = "0.6.0", default-features = false, features = ["ahash"] }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 parity-scale-codec = { version = "1.0.5", default-features = false, features = ["derive"] }
-pin-utils = "0.1.0-alpha.4"
+pin-project = "0.4.6"
 spin = "0.5.2"
-
-[features]
-default = ["std"]
-std = []

--- a/interfaces/syscalls/src/block_on.rs
+++ b/interfaces/syscalls/src/block_on.rs
@@ -50,7 +50,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
     // the `Future`, then waiting for answer on that `FutexWait` message. The `Waker` passed when
     // polling emits a `FutexWake` message when `wake` is called.
 
-    pin_utils::pin_mut!(future);
+    futures::pin_mut!(future);
 
     // This `Arc<AtomicBool>` will be set to true if we are waken up during the polling.
     let woken_up = Arc::new(AtomicBool::new(false));

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -1,0 +1,220 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use core::{
+    fmt,
+    mem::MaybeUninit,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::prelude::*;
+use parity_scale_codec::{DecodeAll, Encode};
+
+/// Emits a message destined to the handler of the given interface.
+///
+/// Returns `Ok` if the message has been successfully dispatched. Returns an error if no handler
+/// is available for that interface.
+/// Whether this function succeeds only depends on whether an interface handler is available. This
+/// function doesn't perform any validity check on the message itself.
+///
+/// If `needs_answer` is true, then we expect an answer to the message to come later. A message ID
+/// is generated and is returned within `Ok(Some(...))`.
+/// If `needs_answer` is false, the function always returns `Ok(None)`.
+///
+/// # Safety
+///
+/// While the action of sending a message is totally safe, the message itself might instruct the
+/// environment to perform actions that would lead to unsafety.
+///
+pub unsafe fn emit_message(
+    interface_hash: &[u8; 32],
+    msg: &impl Encode,
+    needs_answer: bool,
+) -> Result<Option<u64>, EmitErr> {
+    emit_message_raw(interface_hash, &msg.encode(), needs_answer)
+}
+
+/// Emits a message destined to the handler of the given interface.
+///
+/// Returns `Ok` if the message has been successfully dispatched. Returns an error if no handler
+/// is available for that interface.
+/// Whether this function succeeds only depends on whether an interface handler is available. This
+/// function doesn't perform any validity check on the message itself.
+///
+/// # Safety
+///
+/// While the action of sending a message is totally safe, the message itself might instruct the
+/// environment to perform actions that would lead to unsafety.
+///
+pub unsafe fn emit_message_without_response(
+    interface_hash: &[u8; 32],
+    msg: &impl Encode,
+) -> Result<(), EmitErr> {
+    emit_message(interface_hash, msg, false)?;
+    Ok(())
+}
+
+/// Emits a message destined to the handler of the given interface.
+///
+/// Returns `Ok` if the message has been successfully dispatched. Returns an error if no handler
+/// is available for that interface.
+/// Whether this function succeeds only depends on whether an interface handler is available. This
+/// function doesn't perform any validity check on the message itself.
+///
+/// If `needs_answer` is true, then we expect an answer to the message to come later. A message ID
+/// is generated and is returned within `Ok(Some(...))`.
+/// If `needs_answer` is false, the function always returns `Ok(None)`.
+///
+/// # Safety
+///
+/// While the action of sending a message is totally safe, the message itself might instruct the
+/// environment to perform actions that would lead to unsafety.
+///
+pub unsafe fn emit_message_raw(
+    interface_hash: &[u8; 32],
+    buf: &[u8],
+    needs_answer: bool,
+) -> Result<Option<u64>, EmitErr> {
+    let mut message_id_out = MaybeUninit::uninit();
+
+    let ret = crate::ffi::emit_message(
+        interface_hash as *const [u8; 32] as *const _,
+        buf.as_ptr(),
+        buf.len() as u32,
+        needs_answer,
+        message_id_out.as_mut_ptr(),
+    );
+
+    if ret != 0 {
+        return Err(EmitErr::BadInterface);
+    }
+
+    if needs_answer {
+        Ok(Some(message_id_out.assume_init()))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Emis a message, then waits for a response to come back.
+///
+/// Returns `Ok` if the message has been successfully dispatched. Returns an error if no handler
+/// is available for that interface.
+/// Whether this function succeeds only depends on whether an interface handler is available. This
+/// function doesn't perform any validity check on the message itself.
+///
+/// The returned future will cancel the message if it is dropped early.
+///
+/// # Safety
+///
+/// While the action of sending a message is totally safe, the message itself might instruct the
+/// environment to perform actions that would lead to unsafety.
+///
+// TODO: this ties the messaging system to parity_scale_codec; is that a good thing?
+pub unsafe fn emit_message_with_response<T: DecodeAll>(
+    interface_hash: [u8; 32],
+    msg: impl Encode,
+) -> impl Future<Output = Result<T, EmitErr>> {
+    let msg_id = match emit_message(&interface_hash, &msg, true) {
+        Ok(m) => m.unwrap(),
+        Err(err) => return future::Either::Right(future::ready(Err(err))),
+    };
+    let response_fut = crate::message_response(msg_id);
+    future::Either::Left(EmitMessageWithResponse {
+        inner: Some(response_fut),
+        msg_id,
+    })
+}
+
+/// Cancel the given message. No answer will be received.
+pub fn cancel_message(message_id: u64) -> Result<(), CancelMessageErr> {
+    unsafe {
+        if crate::ffi::cancel_message(&message_id) == 0 {
+            Ok(())
+        } else {
+            Err(CancelMessageErr::InvalidMessageId)
+        }
+    }
+}
+
+/// Error that can be retuend by functions that emit a message.
+#[derive(Debug)]
+pub enum EmitErr {
+    /// The given interface has no handler.
+    BadInterface,
+}
+
+impl fmt::Display for EmitErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            EmitErr::BadInterface => write!(f, "The given interface has no handler"),
+        }
+    }
+}
+
+/// Error that can be retuend by [`cancel_message`].
+#[derive(Debug)]
+pub enum CancelMessageErr {
+    /// The message ID is not valid.
+    InvalidMessageId,
+}
+
+impl fmt::Display for CancelMessageErr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CancelMessageErr::InvalidMessageId => write!(f, "Invalid message ID"),
+        }
+    }
+}
+
+/// Future that drives [`emit_message_with_response`] to completion.
+#[must_use]
+#[pin_project::pin_project(PinnedDrop)]
+pub struct EmitMessageWithResponse<T> {
+    #[pin]
+    inner: Option<crate::MessageResponseFuture<T>>,
+    // TODO: redundant with `inner`
+    msg_id: u64,
+}
+
+impl<T: DecodeAll> Future for EmitMessageWithResponse<T> {
+    type Output = Result<T, EmitErr>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        unsafe {
+            let mut this = self.project();
+            let val = match this
+                .inner
+                .as_mut()
+                .map_unchecked_mut(|opt| opt.as_mut().unwrap())
+                .poll(cx)
+            {
+                Poll::Ready(val) => val,
+                Poll::Pending => return Poll::Pending,
+            };
+            *this.inner = None;
+            Poll::Ready(Ok(val))
+        }
+    }
+}
+
+#[pin_project::pinned_drop]
+impl<T> PinnedDrop for EmitMessageWithResponse<T> {
+    fn drop(self: Pin<&mut Self>) {
+        if self.inner.is_some() {
+            let _ = cancel_message(self.msg_id);
+        }
+    }
+}

--- a/interfaces/syscalls/src/response.rs
+++ b/interfaces/syscalls/src/response.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2019  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::ffi::Message;
+
+use alloc::vec::Vec;
+use core::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::prelude::*;
+use parity_scale_codec::DecodeAll;
+
+/// Waits until a response to the given message comes back.
+///
+/// Returns the undecoded response.
+pub fn message_response_sync_raw(msg_id: u64) -> Vec<u8> {
+    match crate::block_on::next_message(&mut [msg_id], true).unwrap() {
+        Message::Response(m) => m.actual_data,
+        _ => panic!(),
+    }
+}
+
+/// Returns a future that is ready when a response to the given message comes back.
+///
+/// The return value is the type the message decodes to.
+// TODO: this ties the messaging system to parity_scale_codec; is that a good thing?
+pub fn message_response<T: DecodeAll>(msg_id: u64) -> MessageResponseFuture<T> {
+    MessageResponseFuture {
+        finished: false,
+        msg_id,
+        marker: PhantomData,
+    }
+}
+
+// TODO: add a variant of message_response but for multiple messages
+
+/// Future that drives `message_response` to completion.
+#[must_use]
+pub struct MessageResponseFuture<T> {
+    msg_id: u64,
+    finished: bool,
+    marker: PhantomData<T>,
+}
+
+impl<T> Future for MessageResponseFuture<T>
+where
+    T: DecodeAll,
+{
+    type Output = T;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        assert!(!self.finished);
+        if let Some(message) = crate::block_on::peek_response(self.msg_id) {
+            self.finished = true;
+            Poll::Ready(DecodeAll::decode_all(&message.actual_data).unwrap())
+        } else {
+            crate::block_on::register_message_waker(self.msg_id, cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl<T> Unpin for MessageResponseFuture<T> {}

--- a/interfaces/tcp/src/lib.rs
+++ b/interfaces/tcp/src/lib.rs
@@ -53,9 +53,11 @@ impl TcpStream {
             },
         });
 
-        let msg_id = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_open, true)
-            .unwrap()
-            .unwrap();
+        let msg_id = unsafe {
+            nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_open, true)
+                .unwrap()
+                .unwrap()
+        };
 
         async move {
             let message: ffi::TcpOpenResponse =
@@ -98,9 +100,11 @@ impl AsyncRead for TcpStream {
             let tcp_read = ffi::TcpMessage::Read(ffi::TcpRead {
                 socket_id: self.handle,
             });
-            let msg_id = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_read, true)
-                .unwrap()
-                .unwrap();
+            let msg_id = unsafe {
+                nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_read, true)
+                    .unwrap()
+                    .unwrap()
+            };
             self.pending_read = Some(Box::pin(nametbd_syscalls_interface::message_response(
                 msg_id,
             )));
@@ -127,9 +131,11 @@ impl AsyncWrite for TcpStream {
             socket_id: self.handle,
             data: buf.to_vec(),
         });
-        let msg_id = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_write, true)
-            .unwrap()
-            .unwrap();
+        let msg_id = unsafe {
+            nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_write, true)
+                .unwrap()
+                .unwrap()
+        };
         self.pending_write = Some(Box::pin(nametbd_syscalls_interface::message_response(
             msg_id,
         )));
@@ -175,11 +181,13 @@ impl tokio_io::AsyncWrite for TcpStream {
 
 impl Drop for TcpStream {
     fn drop(&mut self) {
-        let tcp_close = ffi::TcpMessage::Close(ffi::TcpClose {
-            socket_id: self.handle,
-        });
+        unsafe {
+            let tcp_close = ffi::TcpMessage::Close(ffi::TcpClose {
+                socket_id: self.handle,
+            });
 
-        nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_close, false);
+            nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_close, false);
+        }
     }
 }
 
@@ -204,9 +212,11 @@ impl TcpListener {
             },
         });
 
-        let msg_id = nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_listen, true)
-            .unwrap()
-            .unwrap();
+        let msg_id = unsafe {
+            nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_listen, true)
+                .unwrap()
+                .unwrap()
+        };
 
         let mut local_addr = socket_addr.clone();
 
@@ -249,10 +259,11 @@ impl TcpListener {
             let tcp_accept = ffi::TcpMessage::Accept(ffi::TcpAccept {
                 socket_id: self.handle,
             });
-            let msg_id =
+            let msg_id = unsafe {
                 nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_accept, true)
                     .unwrap()
-                    .unwrap();
+                    .unwrap()
+            };
             self.pending_accept = Some(Box::pin(nametbd_syscalls_interface::message_response(
                 msg_id,
             )));
@@ -262,10 +273,12 @@ impl TcpListener {
 
 impl Drop for TcpListener {
     fn drop(&mut self) {
-        let tcp_close = ffi::TcpMessage::Close(ffi::TcpClose {
-            socket_id: self.handle,
-        });
+        unsafe {
+            let tcp_close = ffi::TcpMessage::Close(ffi::TcpClose {
+                socket_id: self.handle,
+            });
 
-        nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_close, false);
+            nametbd_syscalls_interface::emit_message(&ffi::INTERFACE, &tcp_close, false);
+        }
     }
 }

--- a/interfaces/time/Cargo.toml
+++ b/interfaces/time/Cargo.toml
@@ -12,4 +12,4 @@ pin-project = "0.4.6"
 
 [features]
 default = ["std"]
-std = ["nametbd-syscalls-interface/std"]
+std = []

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -34,28 +34,34 @@ mod instant;
 /// Returns the number of nanoseconds since an arbitrary point in time in the past.
 #[cfg(feature = "std")]
 pub async fn monotonic_clock() -> u128 {
-    let msg = ffi::TimeMessage::GetMonotonic;
-    nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
-        .await
-        .unwrap()
+    unsafe {
+        let msg = ffi::TimeMessage::GetMonotonic;
+        nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+            .await
+            .unwrap()
+    }
 }
 
 /// Returns the number of nanoseconds since the Epoch (January 1st, 1970 at midnight UTC).
 #[cfg(feature = "std")]
 pub async fn system_clock() -> u128 {
-    let msg = ffi::TimeMessage::GetSystem;
-    nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
-        .await
-        .unwrap()
+    unsafe {
+        let msg = ffi::TimeMessage::GetSystem;
+        nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+            .await
+            .unwrap()
+    }
 }
 
 /// Returns a `Future` that yields when the monotonic clock reaches this value.
 #[cfg(feature = "std")]
 pub async fn monotonic_wait_until(until: u128) {
-    let msg = ffi::TimeMessage::WaitMonotonic(until);
-    nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
-        .await
-        .unwrap()
+    unsafe {
+        let msg = ffi::TimeMessage::WaitMonotonic(until);
+        nametbd_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+            .await
+            .unwrap()
+    }
 }
 
 /// Returns a `Future` that outputs after `duration` has elapsed.

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 


### PR DESCRIPTION
Closes #90 

- Adds proper error types.
- Adds documentation.
- Removes the `std` feature. Everything is now `no_std`.
