### PR TITLE
Fix process not resumed after message delivery

### DIFF
--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -511,6 +511,7 @@ impl<T: Clone> Core<T> {
                         thread.resume(Some(wasmi::RuntimeValue::I32(0)));
                         let mut process = self.processes.process_by_id(*pid).unwrap();
                         process.user_data().messages_queue.push_back(message);
+                        try_resume_message_wait(process);
                         CoreRunOutcomeInner::LoopAgain
                     }
                     Some(InterfaceHandler::External) => {


### PR DESCRIPTION
When sending a message to an interface registered by a program, this program wouldn't get woken up in response. This fixes it.