### PR TITLE
Implement lazy-loading interfaces

### DIFF
--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -663,14 +663,18 @@ impl<T: Clone> Core<T> {
                 );
 
                 thread.resume(Some(wasmi::RuntimeValue::I32(0)));
-                let mut process = self.processes.process_by_id(pid).unwrap();
-                process.user_data().messages_queue.push_back(message);
-                try_resume_message_wait(process);
+                let mut interface_handler_proc = self.processes.process_by_id(process).unwrap();
+                interface_handler_proc
+                    .user_data()
+                    .messages_queue
+                    .push_back(message);
             } else {
                 // State inconsistency in the core.
                 unreachable!()
             }
         }
+
+        // TODO: do we have to resume `process`?
 
         Ok(())
     }

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -651,13 +651,12 @@ impl<T: Clone> Core<T> {
             } = thread_user_data
             {
                 assert_eq!(interface, int);
-                let pid = thread.pid();
                 let message = nametbd_syscalls_interface::ffi::Message::Interface(
                     nametbd_syscalls_interface::ffi::InterfaceMessage {
                         interface,
                         index_in_list: 0,
                         message_id,
-                        emitter_pid: Some(pid.into()),
+                        emitter_pid: Some(thread.pid().into()),
                         actual_data: message,
                     },
                 );

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -158,7 +158,7 @@ impl<TExtEx: Clone> System<TExtEx> {
                         params: params.clone(),
                     };
                 }
-                CoreRunOutcome::ThreadWaitUnavailableInterface { .. } => unimplemented!(),
+                CoreRunOutcome::ThreadWaitUnavailableInterface { .. } => {} // TODO: lazy-loading
 
                 CoreRunOutcome::MessageResponse {
                     message_id,

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -94,6 +94,7 @@ pub unsafe fn emit_message_raw(
         buf.as_ptr(),
         buf.len() as u32,
         needs_answer,
+        true,
         message_id_out.as_mut_ptr(),
     );
 

--- a/interfaces/syscalls/src/ffi.rs
+++ b/interfaces/syscalls/src/ffi.rs
@@ -63,6 +63,10 @@ extern "C" {
     /// On success, if `needs_answer` is true, will write the ID of new event into the memory
     /// pointed by `message_id_out`.
     ///
+    /// If `allow_delay` is true, the kernel is allowed to block the thread in order to
+    /// lazily-load a handler for that interface if necessary. If `allow_delay` is false and no
+    /// interface handler is available, the function fails immediately.
+    ///
     /// When this function is being called, a "lock" is being held on the memory pointed by
     /// `interface_hash`, `msg` and `message_id_out`. In particular, it is invalid to modify these
     /// buffers while the function is running.
@@ -71,6 +75,7 @@ extern "C" {
         msg: *const u8,
         msg_len: u32,
         needs_answer: bool,
+        allow_delay: bool,
         message_id_out: *mut u64,
     ) -> u32;
 
@@ -108,7 +113,7 @@ pub enum Message {
     ProcessDestroyed(u64),*/
 }
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct InterfaceMessage {
     /// Interface the message concerns.
     pub interface: [u8; 32],


### PR DESCRIPTION
Fix #28 

Adds a flag for `emit_message` allowing the user to decide whether to allow delivering the message to be delayed waiting for an interface.

For the moment waiting for an interface effectively freezes the process. After #53 and #112, we might revisit this and let processes run in the background.